### PR TITLE
Support resource exclusion

### DIFF
--- a/pkg/plugin/dv_backup_item_action.go
+++ b/pkg/plugin/dv_backup_item_action.go
@@ -20,6 +20,8 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -65,7 +67,11 @@ func (p *DVBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
 // in this case, setting a custom annotation on the item being backed up.
 func (p *DVBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
 	p.log.Info("Executing DVBackupItemAction")
-	p.log.Debugf("Item: %+v", item.GetObjectKind())
+
+	if backup == nil {
+		return nil, nil, fmt.Errorf("backup object nil!")
+	}
+
 	extra := []velero.ResourceIdentifier{}
 
 	metadata, err := meta.Accessor(item)

--- a/pkg/plugin/dv_backup_item_action_test.go
+++ b/pkg/plugin/dv_backup_item_action_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -32,7 +33,7 @@ func TestDV(t *testing.T) {
 	action := NewDVBackupItemAction(logrus.StandardLogger())
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			item, _, _ := action.Execute(tc.dv, nil)
+			item, _, _ := action.Execute(tc.dv, &v1.Backup{})
 
 			metadata, _ := meta.Accessor(item)
 			annotations := metadata.GetAnnotations()
@@ -41,7 +42,7 @@ func TestDV(t *testing.T) {
 	}
 
 	t.Run("DV should request PVC to be backed up as well", func(t *testing.T) {
-		_, extra, _ := action.Execute(&object, nil)
+		_, extra, _ := action.Execute(&object, &v1.Backup{})
 
 		assert.Equal(t, 1, len(extra))
 		assert.Equal(t, "persistentvolumeclaims", extra[0].Resource)
@@ -108,7 +109,7 @@ func TestPVC(t *testing.T) {
 	action := NewDVBackupItemAction(logrus.StandardLogger())
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			item, _, _ := action.Execute(tc.pvc, nil)
+			item, _, _ := action.Execute(tc.pvc, &v1.Backup{})
 
 			metadata, _ := meta.Accessor(item)
 			annotations := metadata.GetAnnotations()

--- a/pkg/plugin/pod_restore_item_action.go
+++ b/pkg/plugin/pod_restore_item_action.go
@@ -20,6 +20,8 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 )
@@ -47,6 +49,10 @@ func (p *PodRestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 // Execute – Launcher Pod should be unconditionally skipped
 func (p *PodRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.log.Info("Running PodRestorePlugin")
+
+	if input == nil {
+		return nil, fmt.Errorf("input object nil!")
+	}
 
 	return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
 }

--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -20,6 +20,8 @@
 package plugin
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
@@ -51,6 +53,10 @@ func (p *VMRestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 // Execute – If VM was running, it must be restored as stopped
 func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
 	p.log.Info("Running VMRestorePlugin")
+
+	if input == nil {
+		return nil, fmt.Errorf("input object nil!")
+	}
 
 	vm := new(kvcore.VirtualMachine)
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), vm); err != nil {

--- a/pkg/plugin/vmi_backup_item_action_test.go
+++ b/pkg/plugin/vmi_backup_item_action_test.go
@@ -17,10 +17,13 @@ import (
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	kvcore "kubevirt.io/client-go/api/v1"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 )
 
 func TestVMIBackupItemAction(t *testing.T) {
-	notPaused := func(vmi *kvcore.VirtualMachineInstance) (bool, error) { return false, nil }
+	returnFalse := func(something ...interface{}) (bool, error) { return false, nil }
+	returnTrue := func(something ...interface{}) (bool, error) { return true, nil }
+
 	nullValidator := func(runtime.Unstructured, []velero.ResourceIdentifier) bool { return true }
 
 	ownedVMI := map[string]interface{}{
@@ -35,6 +38,13 @@ func TestVMIBackupItemAction(t *testing.T) {
 				},
 			},
 		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"volumes": []map[string]interface{}{},
+				},
+			},
+		},
 	}
 	nonOwnedVMI := map[string]interface{}{
 		"apiVersion": "kubevirt.io",
@@ -43,18 +53,201 @@ func TestVMIBackupItemAction(t *testing.T) {
 			"name":      "test-vmi",
 			"namespace": "test-namespace",
 		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"volumes": []map[string]interface{}{},
+				},
+			},
+		},
+	}
+	pausedVMI := map[string]interface{}{
+		"apiVersion": "kubevirt.io",
+		"kind":       "VirtualMachineInterface",
+		"metadata": map[string]interface{}{
+			"name":      "test-vmi",
+			"namespace": "test-namespace",
+			"ownerReferences": []interface{}{
+				map[string]interface{}{
+					"name": "test-owner",
+				},
+			},
+		},
+		"spec": map[string]interface{}{
+			"template": map[string]interface{}{
+				"spec": map[string]interface{}{
+					"volumes": []map[string]interface{}{},
+				},
+			},
+		},
+		"status": map[string]interface{}{
+			"conditions": []map[string]interface{}{
+				{
+					"type":   "Paused",
+					"status": "True",
+				},
+			},
+		},
+	}
+
+	launcherPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-vmi-launcher-pod",
+			Labels: map[string]string{
+				"kubevirt.io": "virt-launcher",
+			},
+			Annotations: map[string]string{
+				"kubevirt.io/domain": "test-vmi",
+			},
+		},
+	}
+	excludedPod := v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "test-namespace",
+			Name:      "test-vmi-launcher-pod",
+			Labels: map[string]string{
+				"kubevirt.io":                   "virt-launcher",
+				"velero.io/exclude-from-backup": "true",
+			},
+			Annotations: map[string]string{
+				"kubevirt.io/domain": "test-vmi",
+			},
+		},
 	}
 
 	testCases := []struct {
-		name        string
-		item        unstructured.Unstructured
-		backup      velerov1.Backup
-		pod         v1.Pod
-		isVmPaused  func(vmi *kvcore.VirtualMachineInstance) (bool, error)
-		expectError bool
-		validator   func(runtime.Unstructured, []velero.ResourceIdentifier) bool
+		name          string
+		item          unstructured.Unstructured
+		backup        velerov1.Backup
+		pod           v1.Pod
+		isPvcExcluded func(something ...interface{}) (bool, error)
+		isVmExcluded  func(something ...interface{}) (bool, error)
+		expectError   bool
+		errorMsg      string
+		validator     func(runtime.Unstructured, []velero.ResourceIdentifier) bool
 	}{
-		{"Owned VMI must include VM in backup",
+		{"Paused VMI can exclude pods from backup",
+			unstructured.Unstructured{
+				Object: pausedVMI,
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"pods"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
+		{"Paused VMI can omit Pod in included resources",
+			unstructured.Unstructured{
+				Object: pausedVMI,
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
+		{"Paused VMI can exclude Pod by label",
+			unstructured.Unstructured{
+				Object: pausedVMI,
+			},
+			velerov1.Backup{},
+			excludedPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
+		{"Running VMI must include Pod in backup",
+			unstructured.Unstructured{
+				Object: ownedVMI,
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines", "persistentvolumeclaims"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			true,
+			"VM is running but launcher pod is not included in the backup",
+			nullValidator,
+		},
+		{"Running VMI must not exclude Pods",
+			unstructured.Unstructured{
+				Object: ownedVMI,
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"pods"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			true,
+			"VM is running but launcher pod is not included in the backup",
+			nullValidator,
+		},
+		{"Running VMI must not exclude its Pod by label",
+			unstructured.Unstructured{
+				Object: ownedVMI,
+			},
+			velerov1.Backup{},
+			excludedPod,
+			returnFalse,
+			returnTrue,
+			true,
+			"VM is running but launcher pod is not included in the backup",
+			nullValidator,
+		},
+		{"Running VMI must include Pod in backup unless it does not include PVCs",
+			unstructured.Unstructured{
+				Object: ownedVMI,
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
+		{"Running VMI must not exclude Pods unless it also excludes PVCs",
+			unstructured.Unstructured{
+				Object: ownedVMI,
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"pods", "persistentvolumeclaims"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
+		{"Owned VMI: backup must include VM",
 			unstructured.Unstructured{
 				Object: ownedVMI,
 			},
@@ -63,23 +256,39 @@ func TestVMIBackupItemAction(t *testing.T) {
 					IncludedResources: []string{"virtualmachineinstances"},
 				},
 			},
-			v1.Pod{},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			true,
+			"VMI owned by a VM and the VM is not included in the backup",
 			nullValidator,
 		},
-		{"Owned and not paused VMI must include VM and Pod in backup",
+		{"Owned VMI: VM must not be excluded from backup",
 			unstructured.Unstructured{
 				Object: ownedVMI,
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
-					IncludedResources: []string{"virtualmachineinstances,virtualmachines"},
+					ExcludedResources: []string{"virtualmachines"},
 				},
 			},
-			v1.Pod{},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			true,
+			"VMI owned by a VM and the VM is not included in the backup",
+			nullValidator,
+		},
+		{"Owned VMI: VM must not be excluded by label",
+			unstructured.Unstructured{
+				Object: ownedVMI,
+			},
+			velerov1.Backup{},
+			launcherPod,
+			returnFalse,
+			returnTrue,
+			true,
+			"VMI owned by a VM and the VM is not included in the backup",
 			nullValidator,
 		},
 		{"Owned VMI must add 'is owned' annotation",
@@ -87,29 +296,17 @@ func TestVMIBackupItemAction(t *testing.T) {
 				Object: ownedVMI,
 			},
 			velerov1.Backup{},
-			v1.Pod{},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			false,
+			"",
 			func(item runtime.Unstructured, extra []velero.ResourceIdentifier) bool {
 				metadata, err := meta.Accessor(item)
 				assert.NoError(t, err)
 
 				return assert.Equal(t, map[string]string{"cdi.kubevirt.io/velero.isOwned": "true"}, metadata.GetAnnotations())
 			},
-		},
-		{"Not owned VMI must include Pod in backup",
-			unstructured.Unstructured{
-				Object: nonOwnedVMI,
-			},
-			velerov1.Backup{
-				Spec: velerov1.BackupSpec{
-					IncludedResources: []string{"virtualmachineinstances"},
-				},
-			},
-			v1.Pod{},
-			notPaused,
-			true,
-			nullValidator,
 		},
 		{"Not owned VMI with DV volumes must include DataVolumes in backup",
 			unstructured.Unstructured{
@@ -131,12 +328,44 @@ func TestVMIBackupItemAction(t *testing.T) {
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
-					IncludedResources: []string{"virtualmachineinstances"},
+					IncludedResources: []string{"virtualmachineinstances", "pods"},
 				},
 			},
-			v1.Pod{},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			true,
+			"VM has DataVolume or PVC volumes and DataVolumes/PVCs is not included in the backup",
+			nullValidator,
+		},
+		{"Not owned VMI with DV volumes must not exclude DataVolumes from backup",
+			unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubevirt.io",
+					"kind":       "VirtualMachineInterface",
+					"metadata": map[string]interface{}{
+						"name":      "test-vmi",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"dataVolume": map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"datavolumes"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			true,
+			"VM has DataVolume or PVC volumes and DataVolumes/PVCs is not included in the backup",
 			nullValidator,
 		},
 		{"Not owned VMI with PVC volumes must include PVCs in backup",
@@ -159,12 +388,44 @@ func TestVMIBackupItemAction(t *testing.T) {
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
-					IncludedResources: []string{"virtualmachineinstances"},
+					IncludedResources: []string{"virtualmachineinstances", "pods"},
 				},
 			},
-			v1.Pod{},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			true,
+			"VM has DataVolume or PVC volumes and DataVolumes/PVCs is not included in the backup",
+			nullValidator,
+		},
+		{"Not owned VMI with PVC volumes must not exclude PVCs from backup",
+			unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubevirt.io",
+					"kind":       "VirtualMachineInterface",
+					"metadata": map[string]interface{}{
+						"name":      "test-vmi",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"persistentVolumeClaim": map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"persistentvolumeclaims"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			true,
+			"VM has DataVolume or PVC volumes and DataVolumes/PVCs is not included in the backup",
 			nullValidator,
 		},
 		{"Launcher pod included in extra resources",
@@ -172,20 +433,11 @@ func TestVMIBackupItemAction(t *testing.T) {
 				Object: nonOwnedVMI,
 			},
 			velerov1.Backup{},
-			v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-namespace",
-					Name:      "test-vmi-launcher-pod",
-					Labels: map[string]string{
-						"kubevirt.io": "virt-launcher",
-					},
-					Annotations: map[string]string{
-						"kubevirt.io/domain": "test-vmi",
-					},
-				},
-			},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			false,
+			"",
 			func(_ runtime.Unstructured, extra []velero.ResourceIdentifier) bool {
 				podResource := velero.ResourceIdentifier{
 					GroupResource: kuberesource.Pods,
@@ -203,6 +455,11 @@ func TestVMIBackupItemAction(t *testing.T) {
 					"metadata": map[string]interface{}{
 						"name":      "test-vmi",
 						"namespace": "test-namespace",
+						"ownerReferences": []interface{}{
+							map[string]interface{}{
+								"name": "test-owner",
+							},
+						},
 					},
 					"spec": map[string]interface{}{
 						"volumes": []interface{}{
@@ -221,9 +478,11 @@ func TestVMIBackupItemAction(t *testing.T) {
 				},
 			},
 			velerov1.Backup{},
-			v1.Pod{},
-			notPaused,
+			launcherPod,
+			returnFalse,
+			returnFalse,
 			false,
+			"",
 			func(_ runtime.Unstructured, extra []velero.ResourceIdentifier) bool {
 				pvcResource := velero.ResourceIdentifier{
 					GroupResource: kuberesource.PersistentVolumeClaims,
@@ -252,13 +511,15 @@ func TestVMIBackupItemAction(t *testing.T) {
 		kubeobjects = append(kubeobjects, &tc.pod)
 		client := k8sfake.NewSimpleClientset(kubeobjects...)
 		action := NewVMIBackupItemAction(logrus.StandardLogger(), client)
-		isVMPaused = tc.isVmPaused
+		isVMExcludedByLabel = func(vmi *kvcore.VirtualMachineInstance) (bool, error) { return tc.isVmExcluded(vmi) }
+		util.IsPVCExcludedByLabel = func(namespace, pvcName string) (bool, error) { return tc.isPvcExcluded(namespace, pvcName) }
 
 		t.Run(tc.name, func(t *testing.T) {
 			output, extra, err := action.Execute(&tc.item, &tc.backup)
 
 			if tc.expectError {
 				assert.Error(t, err)
+				assert.Equal(t, tc.errorMsg, err.Error())
 			} else {
 				assert.NoError(t, err)
 				tc.validator(output, extra)
@@ -407,96 +668,6 @@ func TestAddVolumes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			output := addVolumes(&tc.vmi, []velero.ResourceIdentifier{})
-
-			assert.Equal(t, tc.expected, output)
-		})
-	}
-}
-
-func TestHasDVVolumes(t *testing.T) {
-	testCases := []struct {
-		name     string
-		vmi      kvcore.VirtualMachineInstance
-		expected bool
-	}{
-		{"Should return false if VMI has no DV Volume",
-			kvcore.VirtualMachineInstance{
-				Spec: kvcore.VirtualMachineInstanceSpec{
-					Volumes: []kvcore.Volume{
-						{
-							VolumeSource: kvcore.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
-							},
-						},
-					},
-				},
-			},
-			false,
-		},
-		{"Should return false if VMI has any DV Volume",
-			kvcore.VirtualMachineInstance{
-				Spec: kvcore.VirtualMachineInstanceSpec{
-					Volumes: []kvcore.Volume{
-						{
-							VolumeSource: kvcore.VolumeSource{
-								DataVolume: &kvcore.DataVolumeSource{},
-							},
-						},
-					},
-				},
-			},
-			true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			output := hasDVVolumes(&tc.vmi)
-
-			assert.Equal(t, tc.expected, output)
-		})
-	}
-}
-
-func TestHasPVCVolumes(t *testing.T) {
-	testCases := []struct {
-		name     string
-		vmi      kvcore.VirtualMachineInstance
-		expected bool
-	}{
-		{"Should return true if VMI has any PVC Volume",
-			kvcore.VirtualMachineInstance{
-				Spec: kvcore.VirtualMachineInstanceSpec{
-					Volumes: []kvcore.Volume{
-						{
-							VolumeSource: kvcore.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
-							},
-						},
-					},
-				},
-			},
-			true,
-		},
-		{"Should return false if VMI has no PVC Volumes",
-			kvcore.VirtualMachineInstance{
-				Spec: kvcore.VirtualMachineInstanceSpec{
-					Volumes: []kvcore.Volume{
-						{
-							VolumeSource: kvcore.VolumeSource{
-								DataVolume: &kvcore.DataVolumeSource{},
-							},
-						},
-					},
-				},
-			},
-			false,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			output := hasPVCVolumes(&tc.vmi)
 
 			assert.Equal(t, tc.expected, output)
 		})

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	v1 "k8s.io/api/core/v1"
+	kvcore "kubevirt.io/client-go/api/v1"
 )
 
 func TestIsResourceIncluded(t *testing.T) {
@@ -86,6 +88,241 @@ func TestIsResourceIncluded(t *testing.T) {
 			result := IsResourceIncluded(tc.resource, tc.backup)
 
 			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsResourceExcluded(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resource string
+		backup   *velerov1.Backup
+		expected bool
+	}{
+		{"Empty exclude resources should return false",
+			"pods",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{},
+				},
+			},
+			false,
+		},
+		{"Resource in excuded resources should return true",
+			"pods",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"pods", "virtualmachines", "persistentvolumes"},
+				},
+			},
+			true,
+		},
+		{"Resource not in excluded resources should fail",
+			"pods",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"virtualmachines", "persistentvolumes"},
+				},
+			},
+			false,
+		},
+		{"Capitalization should not matter (resource)",
+			"DataVolumes",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"datavolumes"},
+				},
+			},
+			true,
+		},
+		{"Capitalization should not matter (backup)",
+			"datavolumes",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"DataVolumes"},
+				},
+			},
+			true,
+		},
+		{"Singular/plural should not matter (resource)",
+			"pod",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"pods"},
+				},
+			},
+			true,
+		},
+		{"Singular/plural should not matter (backup)",
+			"pods",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"pod"},
+				},
+			},
+			true,
+		},
+	}
+
+	logrus.SetLevel(logrus.ErrorLevel)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsResourceExcluded(tc.resource, tc.backup)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestRestorePossible(t *testing.T) {
+	returnFalse := func(something ...interface{}) (bool, error) { return false, nil }
+	returnTrue := func(something ...interface{}) (bool, error) { return true, nil }
+	skipFalse := func(volume kvcore.Volume) bool { return false }
+	skipTrue := func(volume kvcore.Volume) bool { return true }
+
+	dvVolumes := []kvcore.Volume{
+		{
+			VolumeSource: kvcore.VolumeSource{
+				DataVolume: &kvcore.DataVolumeSource{},
+			},
+		},
+	}
+	pvcVolumes := []kvcore.Volume{
+		{
+			VolumeSource: kvcore.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
+			},
+		},
+	}
+
+	testCases := []struct {
+		name          string
+		volumes       []kvcore.Volume
+		backup        velerov1.Backup
+		extraTest     func(volume kvcore.Volume) bool
+		isDvExcluded  func(something ...interface{}) (bool, error)
+		isPvcExcluded func(something ...interface{}) (bool, error)
+		expected      bool
+	}{
+		{"Returns true if volumes have no volumes",
+			dvVolumes,
+			velerov1.Backup{},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			true,
+		},
+		{"Returns true if volumes have DV volumes and DVs included in backup",
+			dvVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"datavolumes"},
+				},
+			},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			true,
+		},
+		{"Returns true if volumes have DV volumes, backup excludes datavolumes but skipVolume returns true",
+			dvVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"datavolumes"},
+				},
+			},
+			skipTrue,
+			returnFalse,
+			returnFalse,
+			true,
+		},
+		{"Returns false if volumes have DV volumes and DVs not included in backup",
+			dvVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"pods"},
+				},
+			},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			false,
+		},
+		{"Returns false if volumes have DV volumes and DVs excluded in backup",
+			dvVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"datavolumes"},
+				},
+			},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			false,
+		},
+		{"Returns false if volumes have DV volumes and DV excluded by label",
+			dvVolumes,
+			velerov1.Backup{},
+			skipFalse,
+			returnTrue,
+			returnFalse,
+			false},
+		{"Returns true if volumes have PVC volumes and PVCs included in backup",
+			pvcVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"persistentvolumeclaims"},
+				},
+			},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			true,
+		},
+		{"Returns false if volumes have PVC volumes and PVCs not included in backup",
+			pvcVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"pods"},
+				},
+			},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			false,
+		},
+		{"Returns false if volumes have PVC volumes and PVCs excluded in backup",
+			pvcVolumes,
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"persistentvolumeclaims"},
+				},
+			},
+			skipFalse,
+			returnFalse,
+			returnFalse,
+			false,
+		},
+		{"Returns false if volumes have PVC volumes and PVC excluded by label",
+			pvcVolumes,
+			velerov1.Backup{},
+			skipFalse,
+			returnFalse,
+			returnTrue,
+			false,
+		},
+	}
+
+	logrus.SetLevel(logrus.ErrorLevel)
+	for _, tc := range testCases {
+		IsDVExcludedByLabel = func(namespace, pvcName string) (bool, error) { return tc.isDvExcluded(namespace, pvcName) }
+		IsPVCExcludedByLabel = func(namespace, pvcName string) (bool, error) { return tc.isPvcExcluded(namespace, pvcName) }
+
+		t.Run(tc.name, func(t *testing.T) {
+			possible, err := RestorePossible(tc.volumes, &tc.backup, "", tc.extraTest, &logrus.Logger{})
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, possible)
 		})
 	}
 }


### PR DESCRIPTION
Velero provides a number of options for resource filtering for excluding
objects from backups:
*  –exclude-namespaces
*  –exclude-resources
*  velero.io/exclude-from-backup=true

This PR covers all work required to support all of them.

Signed-off-by: Tomasz Baranski <tbaransk@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

