### PR TITLE
Improve test cleanup and isolation

### DIFF
--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -18,11 +18,6 @@ import (
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 )
 
-const (
-	backupName  = "test-backup"
-	restoreName = "test-restore"
-)
-
 var newVMSpecDVTemplate = func(vmName, size string) *kvv1.VirtualMachine {
 	no := false
 	var zero int64 = 0
@@ -217,10 +212,15 @@ var _ = Describe("Resource includes", func() {
 	var client, _ = util.GetK8sClient()
 	var timeout context.Context
 	var cancelFunc context.CancelFunc
+	var backupName string
+	var restoreName string
 	var r = framework.NewKubernetesReporter()
 
 	BeforeEach(func() {
 		timeout, cancelFunc = context.WithTimeout(context.Background(), 5*time.Minute)
+		t := time.Now().UnixNano()
+		backupName = fmt.Sprintf("test-backup-%d", t)
+		restoreName = fmt.Sprintf("test-restore-%d", t)
 	})
 
 	AfterEach(func() {
@@ -1735,6 +1735,8 @@ var _ = Describe("Resource excludes", func() {
 	var timeout context.Context
 	var cancelFunc context.CancelFunc
 	var namespace *v1.Namespace
+	var backupName string
+	var restoreName string
 	var r = framework.NewKubernetesReporter()
 
 	BeforeEach(func() {
@@ -1742,6 +1744,9 @@ var _ = Describe("Resource excludes", func() {
 		timeout, cancelFunc = context.WithTimeout(context.Background(), 5*time.Minute)
 		namespace, err = CreateNamespace(client)
 		Expect(err).ToNot(HaveOccurred())
+		t := time.Now().UnixNano()
+		backupName = fmt.Sprintf("test-backup-%d", t)
+		restoreName = fmt.Sprintf("test-restore-%d", t)
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
Make sure that backup and restore has unique name for each test,
and that all backups are removed after tests.

Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Make sure that backup and restore has unique name for each test,
and that all backups are removed after tests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

