### PR TITLE
DV test can now run on WFFC storage

### DIFF
--- a/tests/dv_backup_test.go
+++ b/tests/dv_backup_test.go
@@ -66,6 +66,8 @@ var _ = Describe("DV Backup", func() {
 		BeforeEach(func() {
 			var err error
 			dvSpec := NewDataVolumeForBlankRawImage("test-dv", "100Mi")
+			dvSpec.Annotations[forceBindAnnotation] = "true"
+
 			By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 			dv, err = CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	pollInterval = 3 * time.Second
-	waitTime     = 270 * time.Second
-	veleroCLI    = "velero"
+	pollInterval        = 3 * time.Second
+	waitTime            = 270 * time.Second
+	veleroCLI           = "velero"
+	forceBindAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
 )
 
 func CreateVmWithGuestAgent(vmName string) *kvv1.VirtualMachine {


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

