### PR TITLE
Grab exact path of ginkgo binary

### DIFF
--- a/hack/build/build-functest.sh
+++ b/hack/build/build-functest.sh
@@ -19,11 +19,16 @@ set -euo pipefail
 export PATH=$PATH:$HOME/gopath/bin
 
 test_path="tests"
+GOBIN=$(go env GOBIN)
+if [ -d "$GOBIN" ]; then
+  ginkgo_path=$GOBIN/ginkgo
+else
+  ginkgo_path=$(go env GOPATH)/bin/ginkgo
+fi
 (cd $test_path; go install github.com/onsi/ginkgo/ginkgo@latest)
 (cd $test_path; GOFLAGS= go get github.com/onsi/gomega)
-(cd $test_path; go mod  tidy; go mod vendor)
+(cd $test_path; go mod tidy; go mod vendor)
 test_out_path=${test_path}/_out
 mkdir -p ${test_out_path}
-(cd $test_path; ginkgo build .)
+(cd $test_path; $ginkgo_path build .)
 mv ${test_path}/tests.test ${TESTS_OUT_DIR}
-


### PR DESCRIPTION
Signed-off-by: Alex Kalenyuk <akalenyu@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Different builder images vary in setup so adjust ourselves
to be able to get ginkgo binary regardless.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

