### PR TITLE
Use smaller alpine in tests

### DIFF
--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -1391,7 +1391,7 @@ var _ = Describe("Resource includes", func() {
 			// need to be improved
 			XIt("Selecting standalone VMI+DV+PVC+Pod: All objects should be restored", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -1447,7 +1447,7 @@ var _ = Describe("Resource includes", func() {
 
 			It("Selecting standalone VMI+Pod without DV: backup should fail", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -1474,7 +1474,7 @@ var _ = Describe("Resource includes", func() {
 
 			It("Selecting standalone VMI+Pod without PVC: backup should fail", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -1501,7 +1501,7 @@ var _ = Describe("Resource includes", func() {
 
 			It("Selecting standalone VMI without Pod: Backup should fail", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -1719,7 +1719,7 @@ var _ = Describe("Resource includes", func() {
 		Context("[smoke] Standalone VMI", func() {
 			It("Backup of VMIs selected by label should include its DVs, PVCs, and Pods", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -2693,7 +2693,7 @@ var _ = Describe("Resource excludes", func() {
 
 			It("[smoke] Pod included, VMI excluded: backup should succeed, only DV and PVC restored", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -3289,7 +3289,7 @@ var _ = Describe("Resource excludes", func() {
 		Context("[smoke] Standalone VMI", func() {
 			It("VMI included, Pod excluded: should fail if VM is running", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -3315,7 +3315,7 @@ var _ = Describe("Resource excludes", func() {
 
 			It("VMI included, Pod excluded: should succeed if VM is paused", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())
@@ -3377,7 +3377,7 @@ var _ = Describe("Resource excludes", func() {
 			// TODO: investigation in progress
 			XIt("Pod included, VMI excluded: backup should succeed, only DV and PVC restored", func() {
 				By("Creating DVs")
-				dvSpec := NewDataVolumeForFedoraWithGuestAgentImage("test-dv", r.StorageClass)
+				dvSpec := NewDataVolumeForVmWithGuestAgentImage("test-dv", r.StorageClass)
 				By(fmt.Sprintf("Creating DataVolume %s", dvSpec.Name))
 				_, err := CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
 				Expect(err).ToNot(HaveOccurred())

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -31,13 +31,14 @@ const (
 	waitTime            = 600 * time.Second
 	veleroCLI           = "velero"
 	forceBindAnnotation = "cdi.kubevirt.io/storage.bind.immediate.requested"
+	alpineUrl           = "docker://quay.io/kubevirtci/alpine-with-test-tooling-container-disk:2205291325-d8fc489"
 )
 
 func CreateVmWithGuestAgent(vmName string, storageClassName string) *kvv1.VirtualMachine {
 	no := false
 	var zero int64 = 0
 	dataVolumeName := vmName + "-dv"
-	size := "5Gi"
+	size := "1Gi"
 
 	networkData := `ethernets:
   eth0:
@@ -120,8 +121,8 @@ version: 2`
 		TerminationGracePeriodSeconds: &zero,
 	}
 
-	fedoraUrl := "docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk"
 	nodePullMethod := cdiv1.RegistryPullNode
+	containerDiskUrl := alpineUrl
 
 	vmSpec := &kvv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
@@ -143,7 +144,7 @@ version: 2`
 					Spec: cdiv1.DataVolumeSpec{
 						Source: &cdiv1.DataVolumeSource{
 							Registry: &cdiv1.DataVolumeSourceRegistry{
-								URL:        &fedoraUrl,
+								URL:        &containerDiskUrl,
 								PullMethod: &nodePullMethod,
 							},
 						},
@@ -517,9 +518,9 @@ func WaitVirtualMachineDeleted(client kubecli.KubevirtClient, namespace, name st
 	return result, err
 }
 
-func NewDataVolumeForFedoraWithGuestAgentImage(dataVolumeName string, storageClass string) *cdiv1.DataVolume {
-	fedoraUrl := "docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk"
+func NewDataVolumeForVmWithGuestAgentImage(dataVolumeName string, storageClass string) *cdiv1.DataVolume {
 	nodePullMethod := cdiv1.RegistryPullNode
+	containerDiskUrl := alpineUrl
 
 	dvSpec := &cdiv1.DataVolume{
 		ObjectMeta: metav1.ObjectMeta{
@@ -529,7 +530,7 @@ func NewDataVolumeForFedoraWithGuestAgentImage(dataVolumeName string, storageCla
 		Spec: cdiv1.DataVolumeSpec{
 			Source: &cdiv1.DataVolumeSource{
 				Registry: &cdiv1.DataVolumeSourceRegistry{
-					URL:        &fedoraUrl,
+					URL:        &containerDiskUrl,
 					PullMethod: &nodePullMethod,
 				},
 			},
@@ -537,7 +538,7 @@ func NewDataVolumeForFedoraWithGuestAgentImage(dataVolumeName string, storageCla
 				AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 				Resources: v1.ResourceRequirements{
 					Requests: v1.ResourceList{
-						v1.ResourceName(v1.ResourceStorage): resource.MustParse("5Gi"),
+						v1.ResourceName(v1.ResourceStorage): resource.MustParse("1Gi"),
 					},
 				},
 			},


### PR DESCRIPTION
Signed-off-by: Bartosz Rybacki <brybacki@redhat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Change big 5Gig fedora image to smaller 1Gig alpine. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Just checking if tests are faster and more predictable. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

