### PR TITLE
Handle DV that is in progress 

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func main() {
 		BindFlags(pflag.CommandLine).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-vm-action", newVMRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-vmi-action", newVMIRestoreItemAction).
+		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pvc-action", newPVCRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pod-action", newPodRestoreItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-datavolume-action", newDVBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachine-action", newVMBackupItemAction).
@@ -68,6 +69,11 @@ func newVMRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 func newVMIRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	logger.Debug("Creating VMIRestoreItemAction")
 	return plugin.NewVMIRestoreItemAction(logger), nil
+}
+
+func newPVCRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating PvcRestoreItemAction")
+	return plugin.NewPVCRestoreItemAction(logger), nil
 }
 
 func newPodRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {

--- a/pkg/plugin/dv_backup_item_action.go
+++ b/pkg/plugin/dv_backup_item_action.go
@@ -21,12 +21,15 @@ package plugin
 
 import (
 	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	cdiv1 "kubevirt.io/containerized-data-importer/pkg/apis/core/v1beta1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
@@ -74,51 +77,84 @@ func (p *DVBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backu
 
 	extra := []velero.ResourceIdentifier{}
 
-	metadata, err := meta.Accessor(item)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	annotations := metadata.GetAnnotations()
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-
 	kind := item.GetObjectKind().GroupVersionKind().Kind
 	switch kind {
 	case "PersistentVolumeClaim":
-		annotations = p.handlePVC(annotations, metadata)
+		return p.handlePVC(item)
 	case "DataVolume":
-		annotations, extra = p.handleDataVolume(annotations, metadata)
+		return p.handleDataVolume(backup, item)
 	}
-
-	metadata.SetAnnotations(annotations)
 
 	return item, extra, nil
 }
 
-func (p *DVBackupItemAction) handleDataVolume(annotations map[string]string, metadata metav1.Object) (map[string]string, []velero.ResourceIdentifier) {
-	p.log.Infof("handling DataVolume %v/%v", metadata.GetNamespace(), metadata.GetName())
-	// TODO: if DV name will ever be different that PVC name, this must be changed
-	annotations[AnnPrePopulated] = metadata.GetName()
+func (p *DVBackupItemAction) handlePVC(item runtime.Unstructured) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+	metadata, err := meta.Accessor(item)
+	if err != nil {
+		return nil, nil, err
+	}
+	p.log.Infof("handling PVC %v/%v", metadata.GetNamespace(), metadata.GetName())
 
-	extra := []velero.ResourceIdentifier{{
-		GroupResource: kuberesource.PersistentVolumeClaims,
-		Namespace:     metadata.GetNamespace(),
-		Name:          metadata.GetName(),
-	}}
+	dv, err := p.getOwningDataVolume(metadata)
+	if err != nil {
+		return nil, nil, err
+	}
+	if dv != nil && dv.Status.Phase == cdiv1.Succeeded {
+		// make sure an object is marked as populated, so the operation will not be retried after restore
+		annotations := metadata.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[AnnPopulatedFor] = dv.Name
+		metadata.SetAnnotations(annotations)
+	}
 
-	return annotations, extra
+	extra := []velero.ResourceIdentifier{}
+	return item, extra, nil
 }
 
-func (p *DVBackupItemAction) handlePVC(annotations map[string]string, metadata metav1.Object) map[string]string {
-	p.log.Infof("handling PVC %v/%v", metadata.GetNamespace(), metadata.GetName())
+func (p *DVBackupItemAction) handleDataVolume(backup *v1.Backup, item runtime.Unstructured) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
+	var dv cdiv1.DataVolume
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), &dv); err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	p.log.Infof("handling DataVolume %v/%v", dv.GetNamespace(), dv.GetName())
+	extra := []velero.ResourceIdentifier{}
+	dvSucceeded := dv.Status.Phase == cdiv1.Succeeded
+	if dvSucceeded {
+		annotations := dv.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
+		annotations[AnnPrePopulated] = dv.GetName()
+		dv.SetAnnotations(annotations)
+
+		extra = []velero.ResourceIdentifier{{
+			GroupResource: kuberesource.PersistentVolumeClaims,
+			Namespace:     dv.GetNamespace(),
+			Name:          dv.GetName(),
+		}}
+	}
+
+	dvMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&dv)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+
+	return &unstructured.Unstructured{Object: dvMap}, extra, nil
+}
+
+func (p *DVBackupItemAction) getOwningDataVolume(metadata metav1.Object) (*cdiv1.DataVolume, error) {
 	for _, or := range metadata.GetOwnerReferences() {
 		p.log.Infof("or %+v", or)
 		if or.Kind == "DataVolume" {
-			annotations[AnnPopulatedFor] = or.Name
-			break
+			dv, err := util.GetDV(metadata.GetNamespace(), or.Name)
+			if err != nil {
+				return nil, err
+			}
+			return dv, nil
 		}
 	}
-	return annotations
+	return nil, nil
 }

--- a/pkg/plugin/dv_backup_item_action_test.go
+++ b/pkg/plugin/dv_backup_item_action_test.go
@@ -107,7 +107,7 @@ func TestPVC(t *testing.T) {
 					"spec": map[string]interface{}{},
 				},
 			}, false},
-		{"Does not add AnnPopulatedFor when not owned by a another object", &unstructured.Unstructured{
+		{"Does not add AnnPopulatedFor when owned by another object", &unstructured.Unstructured{
 			Object: map[string]interface{}{
 				"apiVersion": "v1",
 				"kind":       "PersistentVolumeClaim",
@@ -125,6 +125,8 @@ func TestPVC(t *testing.T) {
 			},
 		}, false},
 	}
+
+	// TODO SKIP
 
 	logrus.SetLevel(logrus.ErrorLevel)
 	action := NewDVBackupItemAction(logrus.StandardLogger())
@@ -151,6 +153,60 @@ func TestPVC(t *testing.T) {
 			} else {
 				assert.NotContains(t, annotations, AnnPopulatedFor)
 			}
+			assert.NotContains(t, annotations, AnnInProgress)
+
+		})
+	}
+}
+
+func TestUnfinishedPVC(t *testing.T) {
+	testCases := []struct {
+		name string
+		pvc  *unstructured.Unstructured
+	}{
+		{"Adds AnnInProgress when owned by an unfinished DV",
+			&unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "PersistentVolumeClaim",
+					"metadata": map[string]interface{}{
+						"name": "test-pvc",
+						"ownerReferences": []interface{}{
+							map[string]interface{}{
+								"apiVersion": "cdi.kubevirt.io/v1beta1",
+								"kind":       "DataVolume",
+								"name":       "test-datavolume",
+							},
+						},
+					},
+					"spec": map[string]interface{}{},
+				},
+			},
+		},
+	}
+
+	logrus.SetLevel(logrus.ErrorLevel)
+	action := NewDVBackupItemAction(logrus.StandardLogger())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			util.GetDV = func(ns, name string) (*cdiv1.DataVolume, error) {
+				return &cdiv1.DataVolume{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{},
+						Spec:       cdiv1.DataVolumeSpec{},
+						Status: cdiv1.DataVolumeStatus{
+							Phase: "UNKNOWN",
+						},
+					},
+					nil
+			}
+			item, _, err := action.Execute(tc.pvc, &v1.Backup{})
+
+			assert.NoError(t, err)
+			metadata, _ := meta.Accessor(item)
+			annotations := metadata.GetAnnotations()
+
+			assert.Contains(t, annotations, AnnInProgress)
 		})
 	}
 }

--- a/pkg/plugin/pvc_restore_item_action.go
+++ b/pkg/plugin/pvc_restore_item_action.go
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2022 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+
+	corev1api "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// PVCRestoreItemAction is a backup item action for restoring DataVolumes
+type PVCRestoreItemAction struct {
+	log logrus.FieldLogger
+}
+
+// NewPVCRestoreItemAction instantiates a PVCRestoreItemAction.
+func NewPVCRestoreItemAction(log logrus.FieldLogger) *PVCRestoreItemAction {
+	return &PVCRestoreItemAction{log: log}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *PVCRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+			IncludedResources: []string{"PersistentVolumeClaim"},
+		},
+		nil
+}
+
+// Execute if the PVC and the corresponding DV is not SUCCESSFULL - then skip PVC
+func (p *PVCRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.log.Info("Executing PVCRestoreItemAction")
+	if input == nil {
+		return nil, fmt.Errorf("input object nil!")
+	}
+
+	var pvc corev1api.PersistentVolumeClaim
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &pvc); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	p.log.Infof("handling PVC %v/%v", pvc.GetNamespace(), pvc.GetName())
+	annotations := pvc.GetAnnotations()
+	_, inProgress := annotations[AnnInProgress]
+	if inProgress {
+		return velero.NewRestoreItemActionExecuteOutput(input.Item).WithoutRestore(), nil
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/pkg/plugin/pvc_restore_item_action_test.go
+++ b/pkg/plugin/pvc_restore_item_action_test.go
@@ -1,0 +1,51 @@
+package plugin
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestPvcRestoreExecute(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input velero.RestoreItemActionExecuteInput
+	}{
+		{"Skip the unfinished PVC ",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "PersistentVolumeClaim",
+						"metadata": map[string]interface{}{
+							"name": "test-pvc",
+							"annotations": map[string]string{
+								AnnInProgress: "test-pvc",
+							},
+							"ownerReferences": []interface{}{
+								map[string]interface{}{
+									"apiVersion": "cdi.kubevirt.io/v1beta1",
+									"kind":       "DataVolume",
+									"name":       "test-datavolume",
+								},
+							},
+						},
+						"spec": map[string]interface{}{},
+					},
+				},
+			},
+		},
+	}
+
+	logrus.SetLevel(logrus.ErrorLevel)
+	action := NewPVCRestoreItemAction(logrus.StandardLogger())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			item, _ := action.Execute(&tc.input)
+			assert.True(t, item.SkipRestore)
+		})
+	}
+}

--- a/tests/dv_backup_test.go
+++ b/tests/dv_backup_test.go
@@ -24,11 +24,14 @@ const snapshotLocation = "test-location"
 var clientSet *cdiclientset.Clientset
 var kvClient *kubecli.KubevirtClient
 
-var _ = Describe("[smoke] DV Backup", func() {
+var _ = Describe("DV Backup", func() {
 	var client, _ = util.GetK8sClient()
 	var namespace *v1.Namespace
 	var timeout context.Context
 	var cancelFunc context.CancelFunc
+	var backupName string
+	var restoreName string
+
 	var r = framework.NewKubernetesReporter()
 
 	BeforeSuite(func() {
@@ -45,14 +48,28 @@ var _ = Describe("[smoke] DV Backup", func() {
 
 	BeforeEach(func() {
 		var err error
+		timeout, cancelFunc = context.WithTimeout(context.Background(), 5*time.Minute)
+		t := time.Now().UnixNano()
+		backupName = fmt.Sprintf("test-backup-%d", t)
+		restoreName = fmt.Sprintf("test-restore-%d", t)
+
 		namespace, err = CreateNamespace(client)
 		Expect(err).ToNot(HaveOccurred())
-
-		timeout, cancelFunc = context.WithTimeout(context.Background(), 5*time.Minute)
 	})
 
 	AfterEach(func() {
-		err := client.CoreV1().Namespaces().Delete(context.TODO(), namespace.Name, metav1.DeleteOptions{})
+		if CurrentGinkgoTestDescription().Failed {
+			r.FailureCount++
+			r.Dump(CurrentGinkgoTestDescription().Duration)
+		}
+
+		// Deleting the backup also deletes all restores, volume snapshots etc.
+		err := DeleteBackup(timeout, backupName, r.BackupNamespace)
+		if err != nil {
+			fmt.Fprintf(GinkgoWriter, "Err: %s\n", err)
+		}
+
+		err = client.CoreV1().Namespaces().Delete(context.TODO(), namespace.Name, metav1.DeleteOptions{})
 		if err != nil && !apierrs.IsNotFound(err) {
 			Expect(err).ToNot(HaveOccurred())
 		}
@@ -60,7 +77,7 @@ var _ = Describe("[smoke] DV Backup", func() {
 		cancelFunc()
 	})
 
-	Context("Backup", func() {
+	Context("[smoke] Backup", func() {
 		var dv *cdiv1.DataVolume
 
 		BeforeEach(func() {
@@ -79,26 +96,23 @@ var _ = Describe("[smoke] DV Backup", func() {
 		AfterEach(func() {
 			err := DeleteDataVolume(clientSet, namespace.Name, dv.Name)
 			Expect(err).ToNot(HaveOccurred())
-
-			err = DeleteBackup(timeout, "test-backup", r.BackupNamespace)
-			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("Backup should succeed", func() {
-			err := CreateBackupForNamespace(timeout, "test-backup", namespace.Name, snapshotLocation, r.BackupNamespace, true)
+			err := CreateBackupForNamespace(timeout, backupName, namespace.Name, snapshotLocation, r.BackupNamespace, true)
 			Expect(err).ToNot(HaveOccurred())
 
-			phase, err := GetBackupPhase(timeout, "test-backup", r.BackupNamespace)
+			phase, err := GetBackupPhase(timeout, backupName, r.BackupNamespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(phase).To(Equal(velerov1api.BackupPhaseCompleted))
 		})
 
 		It("DataVolume should be restored", func() {
 			By("Crating backup test-backup")
-			err := CreateBackupForNamespace(timeout, "test-backup", namespace.Name, snapshotLocation, r.BackupNamespace, true)
+			err := CreateBackupForNamespace(timeout, backupName, namespace.Name, snapshotLocation, r.BackupNamespace, true)
 			Expect(err).ToNot(HaveOccurred())
 
-			phase, err := GetBackupPhase(timeout, "test-backup", r.BackupNamespace)
+			phase, err := GetBackupPhase(timeout, backupName, r.BackupNamespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(phase).To(Equal(velerov1api.BackupPhaseCompleted))
 
@@ -111,10 +125,90 @@ var _ = Describe("[smoke] DV Backup", func() {
 			Expect(ok).To(BeTrue())
 
 			By("Creating restore test-restore")
-			err = CreateRestoreForBackup(timeout, "test-backup", "test-restore", r.BackupNamespace, true)
+			err = CreateRestoreForBackup(timeout, backupName, restoreName, r.BackupNamespace, true)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = WaitForRestorePhase(timeout, "test-restore", r.BackupNamespace, velerov1api.RestorePhaseCompleted)
+			err = WaitForRestorePhase(timeout, restoreName, r.BackupNamespace, velerov1api.RestorePhaseCompleted)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Checking DataVolume exists")
+			err = WaitForDataVolumePhase(clientSet, namespace.Name, cdiv1.Succeeded, "test-dv")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("[negative] Backup", func() {
+		var dv *cdiv1.DataVolume
+		var sourceNamespace *v1.Namespace
+
+		BeforeEach(func() {
+			var err error
+			sourceNamespace, err = CreateNamespace(client)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := DeleteDataVolume(clientSet, namespace.Name, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = client.CoreV1().Namespaces().Delete(context.TODO(), sourceNamespace.Name, metav1.DeleteOptions{})
+			if err != nil && !apierrs.IsNotFound(err) {
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+		})
+
+		It("xxx DataVolume should be restored", func() {
+			var err error
+			By("Creating source DV")
+			sourceVolumeName := "source-volume"
+			srcDvSpec := NewDataVolumeForBlankRawImage(sourceVolumeName, "100Mi", r.StorageClass)
+			srcDvSpec.Annotations[forceBindAnnotation] = "true"
+
+			By(fmt.Sprintf("Creating DataVolume %s", srcDvSpec.Name))
+			srcDv, err := CreateDataVolumeFromDefinition(clientSet, sourceNamespace.Name, srcDvSpec)
+			Expect(err).ToNot(HaveOccurred())
+			err = WaitForDataVolumePhase(clientSet, srcDv.Namespace, cdiv1.Succeeded, srcDv.Name)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating source pod")
+			podSpec := NewPod("source-use-pod", sourceVolumeName, "while true; do echo hello; sleep 2; done")
+			_, err = (*kvClient).CoreV1().Pods(sourceNamespace.Name).Create(context.TODO(), podSpec, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(func() v1.PodPhase {
+				pod, err := (*kvClient).CoreV1().Pods(sourceNamespace.Name).Get(context.TODO(), podSpec.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				return pod.Status.Phase
+			}, 90*time.Second, 2*time.Second).Should(Equal(v1.PodRunning))
+
+			By("Creating clone DV - object under test")
+			dvSpec := NewCloneDataVolume("test-dv", "100Mi", srcDv.Namespace, srcDv.Name, r.StorageClass)
+			dv, err = CreateDataVolumeFromDefinition(clientSet, namespace.Name, dvSpec)
+
+			By("Creating backup test-backup")
+			err = CreateBackupForNamespace(timeout, backupName, namespace.Name, snapshotLocation, r.BackupNamespace, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			phase, err := GetBackupPhase(timeout, backupName, r.BackupNamespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(phase).To(Equal(velerov1api.BackupPhaseCompleted))
+
+			By("Deleting DataVolume")
+			err = DeleteDataVolume(clientSet, namespace.Name, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+			ok, err := WaitDataVolumeDeleted(clientSet, namespace.Name, dv.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ok).To(BeTrue())
+
+			By("Deleting source pod")
+			err = (*kvClient).CoreV1().Pods(sourceNamespace.Name).Delete(context.TODO(), podSpec.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating restore test-restore")
+			err = CreateRestoreForBackup(timeout, backupName, restoreName, r.BackupNamespace, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = WaitForRestorePhase(timeout, restoreName, r.BackupNamespace, velerov1api.RestorePhaseCompleted)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Checking DataVolume exists")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When the "not finished DataVolume" is stored in backup it should restore correctly and CDI shoud retry the DV action to finish it.
DataVolume is stored as is, without applying "PrePopulated" annotation. The PVC for this DV is stored and marked InProgress, then it is not restored (skipped). 


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Currently it is not possible to skip a PVC during backup. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Handle DV that is in progress
```

