### PR TITLE
Prefetch alpine image

### DIFF
--- a/hack/cluster-deploy-prerequisites.sh
+++ b/hack/cluster-deploy-prerequisites.sh
@@ -32,6 +32,10 @@ _kubectl apply -f https://github.com/kubevirt/containerized-data-importer/releas
 
 _kubectl wait -n kubevirt deployment/virt-operator   --for=condition=Available --timeout=${KUBEVIRT_DEPLOYMENT_TIMEOUT}s
 
+
+${_ssh} node01 "sudo docker pull quay.io/kubevirtci/alpine-with-test-tooling-container-disk:2205291325-d8fc489"
+
+
 # Ensure the KubeVirt CR is created
 count=0
 until _kubectl -n kubevirt get kv kubevirt; do


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Prefetch alpine image so the tests are more deterministic.
With image available there is no unexpected long wait time
for the first fetch (sometimes it is downloaded quickly,
sometimes it takes more than a few minutes)

An example were first test fails on image pull during import:
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-kvp-push-nightly-build-main/1553924187653935104

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

