### PR TITLE
Do not store velero as a blob

### DIFF
--- a/hack/build/run-functional-tests.sh
+++ b/hack/build/run-functional-tests.sh
@@ -21,8 +21,9 @@ source hack/config.sh
 readonly MAX_CDI_WAIT_RETRY=30
 readonly CDI_WAIT_TIME=10
 
-
-VELERO_DIR=$(pwd)/hack/velero
+# when running on a cluster that was externally provided we might not have a velero command available,
+# so now is the time to install it
+kvp::fetch_velero
 
 # parsetTestOpts sets 'pkgs' and test_args
 function parseTestOpts() {
@@ -52,8 +53,9 @@ test_args="${test_args} -ginkgo.v"
 
 test_command="${TESTS_OUT_DIR}/tests.test -test.timeout 360m ${test_args}"
 kubeconfig_arg=${KUBECONFIG:-${kubeconfig}}
+velero_path=$(pwd)/${VELERO_DIR}
 
 (
     cd ${TESTS_DIR}
-    KUBECONFIG=${kubeconfig_arg} PATH=${PATH}:${VELERO_DIR} ${test_command}
+    KUBECONFIG=${kubeconfig_arg} PATH=${PATH}:${velero_path} ${test_command}
 )

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -51,5 +51,19 @@ KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-v0.49.0}
 KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.23}
 KUBEVIRT_DEPLOYMENT_TIMEOUT=${KUBEVIRT_DEPLOYMENT_TIMEOUT:-480}
 KUBEVIRT_DEPLOY_CDI=true
+VELERO_VERSION=${VELERO_VERSION:-v1.8.1}
+VELERO_DIR=_output/velero/bin
 
 source cluster-up/hack/config.sh
+
+function kvp::fetch_velero() {
+  if [[ ! -f "${VELERO_DIR}/velero" ]]; then
+    mkdir -p ${VELERO_DIR}
+    echo >&2 "Downloading velero version ${VELERO_VERSION}..."
+    curl -LO https://github.com/vmware-tanzu/velero/releases/download/${VELERO_VERSION}/velero-${VELERO_VERSION}-linux-amd64.tar.gz \
+      && tar -xzvf velero-${VELERO_VERSION}-linux-amd64.tar.gz \
+      && rm velero-${VELERO_VERSION}-linux-amd64.tar.gz \
+      && chmod u+x velero-${VELERO_VERSION}-linux-amd64/velero \
+      && mv velero-${VELERO_VERSION}-linux-amd64/velero ${VELERO_DIR}/velero
+  fi
+}

--- a/hack/velero/add-plugin.sh
+++ b/hack/velero/add-plugin.sh
@@ -24,12 +24,11 @@ if [ -z "$KUBEVIRTCI_PATH" ]; then
 fi
 
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
-velero_dir=${script_dir}/../velero
 source "${script_dir}"/../config.sh
 
 function wait_plugin_available {
     echo "Waiting 60 seconds for plugin to become available"
-    available=$(${velero_dir}/velero  \
+    available=$(${VELERO_DIR}/velero  \
                     --kubeconfig $(pwd)/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig \
                     plugin get | grep kubevirt-velero | wc -l)
 
@@ -37,18 +36,18 @@ function wait_plugin_available {
     while [[ $available != "6" ]] && [[ $wait_time -lt 60 ]]; do
       wait_time=$((wait_time + 5))
       sleep 5
-      available=$(${velero_dir}/velero  \
+      available=$(${VELERO_DIR}/velero  \
                     --kubeconfig $(pwd)/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig \
                     plugin get | grep kubevirt-velero  | wc -l)
     done
   }
 
-${velero_dir}/velero  \
+${VELERO_DIR}/velero  \
   --kubeconfig $(pwd)/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig \
   plugin add ${DOCKER_PREFIX}/${IMAGE_NAME}:${DOCKER_TAG}
 
 wait_plugin_available
 
-${velero_dir}/velero  \
+${VELERO_DIR}/velero  \
   --kubeconfig $(pwd)/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig \
   plugin get

--- a/hack/velero/remove-plugin.sh
+++ b/hack/velero/remove-plugin.sh
@@ -24,13 +24,12 @@ if [ -z "$KUBEVIRTCI_PATH" ]; then
 fi
 
 script_dir="$(cd "$(dirname "$0")" && pwd -P)"
-velero_dir=${script_dir}/../velero
 source "${script_dir}"/../config.sh
 
 source ${KUBEVIRTCI_PATH}cluster/$KUBEVIRT_PROVIDER/provider.sh
 
 if [[ $(_kubectl get deployment velero -n velero -o json | jq ".spec.template.spec.initContainers[].image" | grep ${DOCKER_PREFIX}/${IMAGE_NAME}:${DOCKER_TAG}) ]]; then
-    ${velero_dir}/velero \
+    ${VELERO_DIR}/velero \
       --kubeconfig $(pwd)/_ci-configs/${KUBEVIRT_PROVIDER}/.kubeconfig \
       plugin remove ${DOCKER_PREFIX}/${IMAGE_NAME}:${DOCKER_TAG}
 fi

--- a/hack/velero/undeploy-velero.sh
+++ b/hack/velero/undeploy-velero.sh
@@ -23,12 +23,9 @@ if [ -z "$KUBEVIRTCI_PATH" ]; then
     )"../../cluster-up/
 fi
 
-
-velero_dir=./hack/velero
 source ./hack/config.sh
 
 source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
 
 _kubectl delete deployment minio -n velero --ignore-not-found=true
-
 _kubectl delete deployment velero -n velero --ignore-not-found=true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Previously velero binary was stored in source control. Now, the script can fetch velero version directly from release page.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

