### PR TITLE
Only use --userns=keep-id for rootless podman

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,8 @@ _output/bin/$(GOOS)/$(GOARCH)/$(BIN): build-dirs ${SRC_FILES}
 		./hack/build/build.sh'"
 
 TTY := $(shell tty -s && echo "-t")
-PODMAN_SPECIFIC_FLAG := $(if $(filter $(OCI_BIN),podman),--userns=keep-id,)
+PODMAN_AND_ROOTLESS := $(shell $(OCI_BIN) info -f '{{json .Host.Security.Rootless}}' 2>/dev/null ; true)
+PODMAN_SPECIFIC_FLAG := $(if $(filter $(PODMAN_AND_ROOTLESS),true),--userns=keep-id,)
 
 shell: build-dirs
 	@echo "running docker: $@"


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes issue mentioned on https://github.com/kubevirt/project-infra/pull/2370

**Special notes for your reviewer**:
Kinda unnecessary, you really have to [go out of your way to use rootless podman now](https://github.com/kubevirt/kubevirtci/pull/833), but it was easy to check for.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```