### PR TITLE
bugfix: should consider excludeded resources by its full name

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -69,7 +69,8 @@ func IsResourceIncluded(resourceKind string, backup *velerov1.Backup) bool {
 	}
 
 	for _, res := range backup.Spec.IncludedResources {
-		if equalIgnorePlural(res, resourceKind) {
+		gr := schema.ParseGroupResource(res)
+		if equalIgnorePlural(gr.Resource, resourceKind) {
 			return true
 		}
 	}
@@ -84,7 +85,8 @@ func IsResourceExcluded(resourceKind string, backup *velerov1.Backup) bool {
 	}
 
 	for _, res := range backup.Spec.ExcludedResources {
-		if equalIgnorePlural(res, resourceKind) {
+		gr := schema.ParseGroupResource(res)
+		if equalIgnorePlural(gr.Resource, resourceKind) {
 			return true
 		}
 	}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -84,6 +84,24 @@ func TestIsResourceIncluded(t *testing.T) {
 			},
 			true,
 		},
+		{"Full resource name should succeed",
+			"virtualmachines",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachines.kubevirt.io"},
+				},
+			},
+			true,
+		},
+		{"Singular/plural full resource name should succeed",
+			"virtualmachines",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachine.kubevirt.io"},
+				},
+			},
+			true,
+		},
 	}
 
 	logrus.SetLevel(logrus.ErrorLevel)
@@ -162,6 +180,24 @@ func TestIsResourceExcluded(t *testing.T) {
 			&velerov1.Backup{
 				Spec: velerov1.BackupSpec{
 					ExcludedResources: []string{"pod"},
+				},
+			},
+			true,
+		},
+		{"Full resource name in excluded resources should return true",
+			"virtualmachines",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"virtualmachines.kubevirt.io"},
+				},
+			},
+			true,
+		},
+		{"Singular/plural full resource name in excluded resources should return true",
+			"virtualmachines",
+			&velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"virtualmachine.kubevirt.io"},
 				},
 			},
 			true,


### PR DESCRIPTION
Signed-off-by: menyakun <lxs137@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #132 

user could specific full resource name, such as "virtualmachines.kubevirt.io", should be backed up

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Consider excludeded resources by its full name
```

