### PR TITLE
[release-v0.6] Use Velero 1.9.4

### DIFF
--- a/hack/config.sh
+++ b/hack/config.sh
@@ -51,7 +51,7 @@ DEPLOYMENT_TIMEOUT=600
 USE_CSI=${USE_CSI:-1}
 USE_RESTIC=${USE_RESTIC:-0}
 CSI_PLUGIN=${CSI_PLUGIN:-velero/velero-plugin-for-csi:v0.5.1}
-VELERO_VERSION=${VELERO_VERSION:-v1.12.0}
+VELERO_VERSION=${VELERO_VERSION:-v1.9.4}
 VELERO_DIR=_output/velero/bin
 
 source cluster-up/hack/config.sh

--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -1307,8 +1307,7 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshot
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
-				// - Namespace
-				expectedItems := 8
+				expectedItems := 7
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1381,8 +1380,7 @@ var _ = Describe("Resource includes", func() {
 				// - 2 VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				// - Namespace
-				expectedItems := 14
+				expectedItems := 13
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 2
 				}
@@ -1426,8 +1424,7 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				// - Namespace
-				expectedItems := 9
+				expectedItems := 8
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1476,8 +1473,7 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				// - Namespace
-				expectedItems := 11
+				expectedItems := 10
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1545,8 +1541,7 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent (PVC)
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				// - Namespace
-				expectedItems := 14
+				expectedItems := 13
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}


### PR DESCRIPTION
This corresponds with downstream OADP for 4.14

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Velero 1.12.0 is too new for downstream testing.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use velero 1.9.4
```

