### PR TITLE
Revert "[release-v0.6] Use Velero 1.9.4"

### DIFF
--- a/hack/config.sh
+++ b/hack/config.sh
@@ -51,7 +51,7 @@ DEPLOYMENT_TIMEOUT=600
 USE_CSI=${USE_CSI:-1}
 USE_RESTIC=${USE_RESTIC:-0}
 CSI_PLUGIN=${CSI_PLUGIN:-velero/velero-plugin-for-csi:v0.5.1}
-VELERO_VERSION=${VELERO_VERSION:-v1.9.4}
+VELERO_VERSION=${VELERO_VERSION:-v1.12.0}
 VELERO_DIR=_output/velero/bin
 
 source cluster-up/hack/config.sh

--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -1307,7 +1307,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshot
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
-				expectedItems := 7
+				// - Namespace
+				expectedItems := 8
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1380,7 +1381,8 @@ var _ = Describe("Resource includes", func() {
 				// - 2 VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 13
+				// - Namespace
+				expectedItems := 14
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 2
 				}
@@ -1424,7 +1426,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 8
+				// - Namespace
+				expectedItems := 9
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1473,7 +1476,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 10
+				// - Namespace
+				expectedItems := 11
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1541,7 +1545,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent (PVC)
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 13
+				// - Namespace
+				expectedItems := 14
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}


### PR DESCRIPTION
Reverts kubevirt/kubevirt-velero-plugin#197
This brunch should use velero version 1.12.Z