### PR TITLE
[release-v0.6] update velero back to 1.12.Z also update velero-plugin-for-csi to match the velero version

### DIFF
--- a/hack/config.sh
+++ b/hack/config.sh
@@ -51,7 +51,7 @@ DEPLOYMENT_TIMEOUT=600
 USE_CSI=${USE_CSI:-1}
 USE_RESTIC=${USE_RESTIC:-0}
 CSI_PLUGIN=${CSI_PLUGIN:-velero/velero-plugin-for-csi:v0.5.1}
-VELERO_VERSION=${VELERO_VERSION:-v1.9.4}
+VELERO_VERSION=${VELERO_VERSION:-v1.12.0}
 VELERO_DIR=_output/velero/bin
 
 source cluster-up/hack/config.sh

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -50,8 +50,8 @@ _ssh=${KUBEVIRTCI_PATH}ssh.sh
 DEPLOYMENT_TIMEOUT=600
 USE_CSI=${USE_CSI:-1}
 USE_RESTIC=${USE_RESTIC:-0}
-CSI_PLUGIN=${CSI_PLUGIN:-velero/velero-plugin-for-csi:v0.5.1}
-VELERO_VERSION=${VELERO_VERSION:-v1.12.0}
+CSI_PLUGIN=${CSI_PLUGIN:-velero/velero-plugin-for-csi:v0.6.3}
+VELERO_VERSION=${VELERO_VERSION:-v1.12.3}
 VELERO_DIR=_output/velero/bin
 
 source cluster-up/hack/config.sh

--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -1307,7 +1307,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshot
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
-				expectedItems := 7
+				// - Namespace
+				expectedItems := 8
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1380,7 +1381,8 @@ var _ = Describe("Resource includes", func() {
 				// - 2 VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 13
+				// - Namespace
+				expectedItems := 14
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 2
 				}
@@ -1424,7 +1426,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 8
+				// - Namespace
+				expectedItems := 9
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1473,7 +1476,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 10
+				// - Namespace
+				expectedItems := 11
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}
@@ -1541,7 +1545,8 @@ var _ = Describe("Resource includes", func() {
 				// - VolumeSnapshotContent (PVC)
 				// - VolumeSpapshotClass
 				// - DataVolume CRD
-				expectedItems := 13
+				// - Namespace
+				expectedItems := 14
 				if framework.IsDataVolumeGC(f.KvClient) {
 					expectedItems -= 1
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
Use velero version 1.12 for 0.6 plugin version

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use velero 1.12.Z for 0.6 release
```

