### PR TITLE
clear MAC addresses on restore

### DIFF
--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -63,6 +63,10 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 		return nil, errors.WithStack(err)
 	}
 
+	for i := 0; i < len(vm.Spec.Template.Spec.Domain.Devices.Interfaces); i++ {
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
+	}
+
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kvcore "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 )
 
 // VIMRestorePlugin is a VMI restore item action plugin for Velero (duh!)
@@ -63,8 +64,11 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 		return nil, errors.WithStack(err)
 	}
 
-	for i := 0; i < len(vm.Spec.Template.Spec.Domain.Devices.Interfaces); i++ {
-		vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
+	if util.IsMacAdressClearedByAnnotation(vm) {
+		p.log.Info("Clear virtual machine MAC addresses")
+		for i := 0; i < len(vm.Spec.Template.Spec.Domain.Devices.Interfaces); i++ {
+			vm.Spec.Template.Spec.Domain.Devices.Interfaces[i].MacAddress = ""
+		}
 	}
 
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)

--- a/pkg/plugin/vm_restore_item_action_test.go
+++ b/pkg/plugin/vm_restore_item_action_test.go
@@ -30,6 +30,8 @@ func TestVmRestoreExecute(t *testing.T) {
 						},
 						},
 					},
+					"template": map[string]interface{}{
+					},
 				},
 			},
 		},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -28,6 +28,7 @@ import (
 )
 
 const VELERO_EXCLUDE_LABEL = "velero.io/exclude-from-backup"
+const CLEAR_MAC_ADDRESS_ANNOTATION = "restore.kubevirt.io/clear-mac-address"
 
 func GetK8sClient() (*kubernetes.Clientset, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -364,4 +365,13 @@ func AddVMIObjectGraph(spec v1.VirtualMachineInstanceSpec, namespace string, ext
 
 	return extra
 
+}
+
+func IsMacAdressClearedByAnnotation(vm *v1.VirtualMachine) (bool) {
+	annotations := vm.GetAnnotations()
+	if annotations == nil {
+		return false
+	}
+	annotation, ok := annotations[CLEAR_MAC_ADDRESS_ANNOTATION]
+	return ok && annotation == "true"
 }

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -581,3 +581,55 @@ func TestAddVMIObjectGraph(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMacAddressCleared(t *testing.T) {
+	testCases := []struct {
+		name     string
+		resource string
+		vm       kvcore.VirtualMachine
+		expected bool
+	}{
+		{"Clear mac addres should return false",
+			"VirtualMachine",
+			kvcore.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+					},
+				},
+			},
+			false,
+		},
+		{"Clear mac addres should return false",
+			"VirtualMachine",
+			kvcore.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CLEAR_MAC_ADDRESS_ANNOTATION : "false",
+					},
+				},
+			},
+			false,
+		},
+		{"Clear mac addres should return true",
+			"VirtualMachine",
+			kvcore.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						CLEAR_MAC_ADDRESS_ANNOTATION : "true",
+					},
+				},
+			},
+			true,
+		},
+	
+	}
+
+	logrus.SetLevel(logrus.ErrorLevel)
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := IsMacAdressClearedByAnnotation(&tc.vm)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When a virtual machine is restored to an alternate namespace, the virtual machine is restored with the same MAC address as the original virtual machine. This results in a MAC address conflict when the original virtual machine is still running on the original namespace.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
 https://github.com/kubevirt/kubevirt-velero-plugin/issues/199
 
**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

