### PR TITLE
Clear VM/VMI mac addresses when restoring to a different namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,5 +253,5 @@ cluster-up:
 cluster-down:
 	@cluster-up/down.sh
 
-cluster-sync: local-undeploy-velero local-deploy-velero remove-plugin cluster-push-image add-plugin
+cluster-sync: local-undeploy-velero local-deploy-velero cluster-push-image add-plugin
 	@echo -e "${GREEN}Plugin redeployed${WHITE}"

--- a/hack/build/build-functest.sh
+++ b/hack/build/build-functest.sh
@@ -25,7 +25,7 @@ if [ -d "$GOBIN" ]; then
 else
   ginkgo_path=$(go env GOPATH)/bin/ginkgo
 fi
-(cd $test_path; go install github.com/onsi/ginkgo/v2/ginkgo@v2.4.0)
+(cd $test_path; go install github.com/onsi/ginkgo/v2/ginkgo@v2.17.1)
 test_out_path=${test_path}/_out
 mkdir -p ${test_out_path}
 (cd $test_path; $ginkgo_path build .)

--- a/hack/velero/undeploy-velero.sh
+++ b/hack/velero/undeploy-velero.sh
@@ -27,5 +27,10 @@ source ./hack/config.sh
 
 source cluster-up/cluster/$KUBEVIRT_PROVIDER/provider.sh
 
-_kubectl delete deployment minio -n velero --ignore-not-found=true
-_kubectl delete deployment velero -n velero --ignore-not-found=true
+kvp::fetch_velero
+
+if [[ $(_kubectl get deployments -n velero | grep velero) ]]; then
+  ${VELERO_DIR}/velero uninstall \
+    --force \
+    --wait
+fi

--- a/pkg/plugin/vm_restore_item_action_test.go
+++ b/pkg/plugin/vm_restore_item_action_test.go
@@ -5,8 +5,11 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kvcore "kubevirt.io/api/core/v1"
 )
 
 func TestVmRestoreExecute(t *testing.T) {
@@ -16,7 +19,8 @@ func TestVmRestoreExecute(t *testing.T) {
 				"apiVersion": "kubevirt.io/v1alpha3",
 				"kind":       "VirtualMachine",
 				"metadata": map[string]interface{}{
-					"name": "test-vm",
+					"name":      "test-vm",
+					"namespace": "test-namespace",
 				},
 				"spec": map[string]interface{}{
 					"running": true,
@@ -30,9 +34,24 @@ func TestVmRestoreExecute(t *testing.T) {
 						},
 						},
 					},
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"interfaces": []map[string]interface{}{
+										{
+											"name":       "default",
+											"macAddress": "00:00:00:00:00:00",
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
+		Restore: &api.Restore{},
 	}
 
 	logrus.SetLevel(logrus.InfoLevel)
@@ -62,5 +81,30 @@ func TestVmRestoreExecute(t *testing.T) {
 		assert.Equal(t, 2, len(dvs))
 		assert.Equal(t, "test-dv-1", dvs[0].Name)
 		assert.Equal(t, "test-dv-2", dvs[1].Name)
+	})
+
+	t.Run("Should keep mac if restoring to same namespace", func(t *testing.T) {
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		vm := new(kvcore.VirtualMachine)
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(output.UpdatedItem.UnstructuredContent(), vm)
+		assert.Nil(t, err)
+		assert.Equal(t, vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress, "00:00:00:00:00:00")
+		_, ok := vm.GetAnnotations()[AnnClearedMacs]
+		assert.False(t, ok)
+	})
+
+	t.Run("Should delete mac if restoring to different namespace", func(t *testing.T) {
+		input.Restore.Spec.NamespaceMapping = map[string]string{"test-namespace": "new-namespace"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		vm := new(kvcore.VirtualMachine)
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(output.UpdatedItem.UnstructuredContent(), vm)
+		assert.Nil(t, err)
+		assert.Equal(t, vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress, "")
+		val := vm.GetAnnotations()[AnnClearedMacs]
+		assert.Equal(t, val, "true")
 	})
 }

--- a/pkg/plugin/vmi_restore_item_action_test.go
+++ b/pkg/plugin/vmi_restore_item_action_test.go
@@ -5,17 +5,23 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	kvcore "kubevirt.io/api/core/v1"
 )
 
 func TestVmiRestoreExecute(t *testing.T) {
 	testCases := []struct {
-		name   string
-		input  velero.RestoreItemActionExecuteInput
-		skip   bool
-		labels map[string]string
+		name            string
+		input           velero.RestoreItemActionExecuteInput
+		skip            bool
+		labels          map[string]string
+		checkMac        bool
+		targetNamespace string
+		mac             string
 	}{
 		{"Owned VMI should be skipped",
 			velero.RestoreItemActionExecuteInput{
@@ -29,13 +35,16 @@ func TestVmiRestoreExecute(t *testing.T) {
 							"annotations": map[string]string{
 								"cdi.kubevirt.io/velero.isOwned": "true",
 							},
-							"labels": map[string]string{},
 						},
 					},
 				},
+				Restore: &velerov1.Restore{},
 			},
 			true,
 			map[string]string{},
+			false,
+			"",
+			"",
 		},
 		{"Standalone VMI should not be skipped",
 			velero.RestoreItemActionExecuteInput{
@@ -46,13 +55,16 @@ func TestVmiRestoreExecute(t *testing.T) {
 						"metadata": map[string]interface{}{
 							"name":      "test-vmi",
 							"namespace": "test-namespace",
-							"labels":    map[string]string{},
 						},
 					},
 				},
+				Restore: &velerov1.Restore{},
 			},
 			false,
-			map[string]string{},
+			nil,
+			false,
+			"",
+			"",
 		},
 		{"Restricted labels should be removed",
 			velero.RestoreItemActionExecuteInput{
@@ -75,11 +87,79 @@ func TestVmiRestoreExecute(t *testing.T) {
 						},
 					},
 				},
+				Restore: &velerov1.Restore{},
 			},
 			false,
 			map[string]string{
 				"some.other/label": "test-value",
 			},
+			false,
+			"",
+			"",
+		},
+		{"Standalone VMI should not be skipped and mac should not be cleared",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "kubevirt.io",
+						"kind":       "VirtualMachineInstance",
+						"metadata": map[string]interface{}{
+							"name":      "test-vmi",
+							"namespace": "test-namespace",
+						},
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"interfaces": []map[string]interface{}{
+										{
+											"name":       "default",
+											"macAddress": "00:00:00:00:00:00",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Restore: &velerov1.Restore{},
+			},
+			false,
+			nil,
+			true,
+			"",
+			"00:00:00:00:00:00",
+		},
+		{"Standalone VMI should not be skipped and mac should be cleared",
+			velero.RestoreItemActionExecuteInput{
+				Item: &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "kubevirt.io",
+						"kind":       "VirtualMachineInstance",
+						"metadata": map[string]interface{}{
+							"name":      "test-vmi",
+							"namespace": "test-namespace",
+						},
+						"spec": map[string]interface{}{
+							"domain": map[string]interface{}{
+								"devices": map[string]interface{}{
+									"interfaces": []map[string]interface{}{
+										{
+											"name":       "default",
+											"macAddress": "00:00:00:00:00:00",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Restore: &velerov1.Restore{},
+			},
+			false,
+			nil,
+			true,
+			"new-namespace",
+			"",
 		},
 	}
 
@@ -87,6 +167,11 @@ func TestVmiRestoreExecute(t *testing.T) {
 	action := NewVMIRestoreItemAction(logrus.StandardLogger())
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			if tc.targetNamespace != "" {
+				tc.input.Restore.Spec.NamespaceMapping = map[string]string{
+					"test-namespace": tc.targetNamespace,
+				}
+			}
 			output, err := action.Execute(&tc.input)
 
 			assert.NoError(t, err)
@@ -95,6 +180,12 @@ func TestVmiRestoreExecute(t *testing.T) {
 				metadata, err := meta.Accessor(output.UpdatedItem)
 				assert.NoError(t, err)
 				assert.Equal(t, tc.labels, metadata.GetLabels())
+			}
+			if tc.checkMac {
+				vmi := new(kvcore.VirtualMachineInstance)
+				err = runtime.DefaultUnstructuredConverter.FromUnstructured(output.UpdatedItem.UnstructuredContent(), vmi)
+				assert.Nil(t, err)
+				assert.Equal(t, tc.mac, vmi.Spec.Domain.Devices.Interfaces[0].MacAddress)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When restoring a VM to same namespace, let's preserve the MACs.  Otherwise clear them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Clear VM/VMI mac addresses when restoring to a different namespace
```

