### PR TITLE
Skip restoring hotplug pod

### DIFF
--- a/pkg/plugin/pod_restore_item_action.go
+++ b/pkg/plugin/pod_restore_item_action.go
@@ -42,7 +42,7 @@ func (p *PodRestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 		IncludedResources: []string{
 			"Pod",
 		},
-		LabelSelector: "kubevirt.io=virt-launcher",
+		LabelSelector: "kubevirt.io in (virt-launcher, hotplug-disk)",
 	}, nil
 }
 

--- a/pkg/plugin/pod_restore_item_action_test.go
+++ b/pkg/plugin/pod_restore_item_action_test.go
@@ -51,6 +51,14 @@ func TestPodRestoreApplyTo(t *testing.T) {
 				},
 			},
 		},
+		{"Match hotplug pod",
+			true,
+			core.Pod{
+				ObjectMeta: v1.ObjectMeta{
+					Labels: map[string]string{"kubevirt.io": "hotplug-disk"},
+				},
+			},
+		},
 		{"Don't match non-launcher pods",
 			false,
 			core.Pod{


### PR DESCRIPTION
Once the vm is started the hotplug process will
create the pod as needed.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
No need to restore the hotplug pod, it will be recreated once the disk will be hotplugged when the vm is running.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip restore hotplug pod
```

