### PR TITLE
tests: Fix poll of backup phase

### DIFF
--- a/tests/framework/backup.go
+++ b/tests/framework/backup.go
@@ -230,7 +230,8 @@ func WaitForBackupPhase(ctx context.Context, backupName string, backupNamespace 
 	err := wait.PollImmediate(pollInterval, waitTime, func() (bool, error) {
 		backup, err := GetBackup(ctx, backupName, backupNamespace)
 		if err != nil {
-			return false, err
+			ginkgo.By(fmt.Sprintf("Failed getting backup: %s", err.Error()))
+			return false, nil
 		}
 		phase := backup.Status.Phase
 		ginkgo.By(fmt.Sprintf("Waiting for backup phase %v, got %v", expectedPhase, phase))


### PR DESCRIPTION
Incase of error in getting the backup we exited the poll. Instead we should print the error and try polling again the error might be temporary.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

