### PR TITLE
Ignore VMIs from backup when owner VMs are excluded

### DIFF
--- a/pkg/plugin/vmi_backup_item_action.go
+++ b/pkg/plugin/vmi_backup_item_action.go
@@ -79,6 +79,15 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 		return nil, nil, errors.WithStack(err)
 	}
 
+	// There's no point in backing up a VMI when it's owned by a VM excluded from the backup
+	shouldExclude, err := shouldExcludeVMI(vmi, backup)
+	if err != nil {
+		return nil, nil, errors.WithStack(err)
+	}
+	if shouldExclude {
+		return nil, nil, nil
+	}
+
 	if !util.IsVMIPaused(vmi) {
 		if !util.IsResourceInBackup("pods", backup) && util.IsResourceInBackup("persistentvolumeclaims", backup) {
 			return nil, nil, fmt.Errorf("VM is running but launcher pod is not included in the backup")
@@ -95,19 +104,6 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 	}
 
 	if isVMIOwned(vmi) {
-		if !util.IsResourceInBackup("virtualmachines", backup) {
-			return nil, nil, fmt.Errorf("VMI owned by a VM and the VM is not included in the backup")
-		}
-
-		excluded, err := isVMExcludedByLabel(vmi)
-		if err != nil {
-			return nil, nil, errors.WithStack(err)
-		}
-
-		if excluded {
-			return nil, nil, fmt.Errorf("VMI owned by a VM and the VM is not included in the backup")
-		}
-
 		util.AddAnnotation(item, AnnIsOwned, "true")
 	} else {
 		restore, err := util.RestorePossible(vmi.Spec.Volumes, backup, vmi.Namespace, func(volume kvcore.Volume) bool { return false }, p.log)
@@ -125,6 +121,24 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 	}
 
 	return item, extra, nil
+}
+
+// shouldExcludeVMI checks wether a VMI owned by VM should be backed up or ignored
+func shouldExcludeVMI(vmi *kvcore.VirtualMachineInstance, backup *v1.Backup) (bool, error) {
+	if !isVMIOwned(vmi) {
+		return false, nil
+	}
+
+	if !util.IsResourceInBackup("virtualmachines", backup) {
+		return true, nil
+	}
+
+	excluded, err := isVMExcludedByLabel(vmi)
+	if err != nil {
+		return false, err
+	}
+
+	return excluded, nil
 }
 
 func isVMIOwned(vmi *kvcore.VirtualMachineInstance) bool {

--- a/pkg/plugin/vmi_backup_item_action_test.go
+++ b/pkg/plugin/vmi_backup_item_action_test.go
@@ -139,6 +139,7 @@ func TestVMIBackupItemAction(t *testing.T) {
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines"},
 					ExcludedResources: []string{"pods"},
 				},
 			},
@@ -169,7 +170,11 @@ func TestVMIBackupItemAction(t *testing.T) {
 			unstructured.Unstructured{
 				Object: pausedVMI,
 			},
-			velerov1.Backup{},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines", "pods"},
+				},
+			},
 			excludedPod,
 			returnFalse,
 			returnFalse,
@@ -199,6 +204,7 @@ func TestVMIBackupItemAction(t *testing.T) {
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines", "persistentvolumeclaims"},
 					ExcludedResources: []string{"pods"},
 				},
 			},
@@ -213,10 +219,14 @@ func TestVMIBackupItemAction(t *testing.T) {
 			unstructured.Unstructured{
 				Object: ownedVMI,
 			},
-			velerov1.Backup{},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines"},
+				},
+			},
 			excludedPod,
 			returnFalse,
-			returnTrue,
+			returnFalse,
 			true,
 			"VM is running but launcher pod is not included in the backup",
 			nullValidator,
@@ -243,6 +253,7 @@ func TestVMIBackupItemAction(t *testing.T) {
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines"},
 					ExcludedResources: []string{"pods", "persistentvolumeclaims"},
 				},
 			},
@@ -253,48 +264,37 @@ func TestVMIBackupItemAction(t *testing.T) {
 			"",
 			nullValidator,
 		},
-		{"Owned VMI: backup must include VM",
+		{"Owned VMI: Won't backup VMI if VMs are excluded",
 			unstructured.Unstructured{
 				Object: ownedVMI,
 			},
 			velerov1.Backup{
 				Spec: velerov1.BackupSpec{
 					IncludedResources: []string{"virtualmachineinstances"},
-				},
-			},
-			launcherPod,
-			returnFalse,
-			returnFalse,
-			true,
-			"VMI owned by a VM and the VM is not included in the backup",
-			nullValidator,
-		},
-		{"Owned VMI: VM must not be excluded from backup",
-			unstructured.Unstructured{
-				Object: ownedVMI,
-			},
-			velerov1.Backup{
-				Spec: velerov1.BackupSpec{
 					ExcludedResources: []string{"virtualmachines"},
 				},
 			},
 			launcherPod,
 			returnFalse,
 			returnFalse,
-			true,
-			"VMI owned by a VM and the VM is not included in the backup",
+			false,
+			"",
 			nullValidator,
 		},
-		{"Owned VMI: VM must not be excluded by label",
+		{"Owned VMI: Will ignore VMI if VM is excluded by label",
 			unstructured.Unstructured{
 				Object: ownedVMI,
 			},
-			velerov1.Backup{},
+			velerov1.Backup{
+				Spec: velerov1.BackupSpec{
+					IncludedResources: []string{"virtualmachineinstances", "virtualmachines"},
+				},
+			},
 			launcherPod,
 			returnFalse,
 			returnTrue,
-			true,
-			"VMI owned by a VM and the VM is not included in the backup",
+			false,
+			"",
 			nullValidator,
 		},
 		{"Owned VMI must add 'is owned' annotation",

--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -863,7 +863,7 @@ var _ = Describe("Resource includes", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:10198]Selecting VMI (with DV+PVC+Pod) but not VM: Backing up VMI should fail", func() {
+			It("[test_id:10198]Selecting VMI (with DV+PVC+Pod) but not VM: Empty backup without failure", func() {
 				By("Creating VirtualMachine")
 				vmSpec := newVMSpecBlankDVTemplate(includedVMName, "100Mi")
 				_, err := framework.CreateVirtualMachineFromDefinition(f.KvClient, f.Namespace.Name, vmSpec)
@@ -880,11 +880,25 @@ var _ = Describe("Resource includes", func() {
 				resources := "datavolumes,virtualmachineinstances,pods,persistentvolumeclaims,persistentvolumes,volumesnapshots,volumesnapshotcontents"
 				err = framework.CreateBackupForResources(timeout, backupName, resources, f.Namespace.Name, snapshotLocation, f.BackupNamespace, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhasePartiallyFailed)
+				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhaseCompleted)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Deleting VirtualMachineInstance")
+				err = framework.DeleteVirtualMachineInstance(f.KvClient, f.Namespace.Name, includedVMName)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating restore")
+				err = framework.CreateRestoreForBackup(timeout, backupName, restoreName, f.BackupNamespace, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = framework.WaitForRestorePhase(timeout, restoreName, f.BackupNamespace, velerov1api.RestorePhaseCompleted)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying VMI not present")
+				_, err = framework.GetVirtualMachineInstance(f.KvClient, f.Namespace.Name, "test-vmi")
+				Expect(err).To(HaveOccurred())
 			})
 
-			It("[test_id:10199]Selecting VMI (without DV+PVC+Pod) but not VM: Backing up VMI should fail", func() {
+			It("[test_id:10199]Selecting VMI (without DV+PVC+Pod) but not VM: Empty backup without failure", func() {
 				By("Creating VirtualMachine")
 				vmSpec := newVMSpecBlankDVTemplate(includedVMName, "100Mi")
 				_, err := framework.CreateVirtualMachineFromDefinition(f.KvClient, f.Namespace.Name, vmSpec)
@@ -901,8 +915,22 @@ var _ = Describe("Resource includes", func() {
 				resources := "virtualmachineinstances"
 				err = framework.CreateBackupForResources(timeout, backupName, resources, f.Namespace.Name, snapshotLocation, f.BackupNamespace, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhasePartiallyFailed)
+				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhaseCompleted)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Deleting VirtualMachineInstance")
+				err = framework.DeleteVirtualMachineInstance(f.KvClient, f.Namespace.Name, includedVMName)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating restore")
+				err = framework.CreateRestoreForBackup(timeout, backupName, restoreName, f.BackupNamespace, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = framework.WaitForRestorePhase(timeout, restoreName, f.BackupNamespace, velerov1api.RestorePhaseCompleted)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying VMI not present")
+				_, err = framework.GetVirtualMachineInstance(f.KvClient, f.Namespace.Name, "test-vmi")
+				Expect(err).To(HaveOccurred())
 			})
 		})
 
@@ -2129,7 +2157,7 @@ var _ = Describe("Resource excludes", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:10227]Running VM excluded: backup should fail", func() {
+			It("[test_id:10227]Running VM excluded: empty backup without failure", func() {
 				By("Creating VirtualMachines")
 				vmSpec := newVMSpecBlankDVTemplate(includedVMName, "100Mi")
 				_, err := framework.CreateVirtualMachineFromDefinition(f.KvClient, f.Namespace.Name, vmSpec)
@@ -2145,8 +2173,22 @@ var _ = Describe("Resource excludes", func() {
 				resources := "virtualmachine"
 				err = framework.CreateBackupForNamespaceExcludeResources(timeout, backupName, f.Namespace.Name, resources, snapshotLocation, f.BackupNamespace, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhasePartiallyFailed)
+				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhaseCompleted)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Deleting VirtualMachineInstance")
+				err = framework.DeleteVirtualMachineInstance(f.KvClient, f.Namespace.Name, includedVMName)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating restore")
+				err = framework.CreateRestoreForBackup(timeout, backupName, restoreName, f.BackupNamespace, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = framework.WaitForRestorePhase(timeout, restoreName, f.BackupNamespace, velerov1api.RestorePhaseCompleted)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying VMI not present")
+				_, err = framework.GetVirtualMachineInstance(f.KvClient, f.Namespace.Name, "test-vmi")
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("[test_id:10228]Stopped VM excluded: DV+PVC should be restored", func() {
@@ -2940,7 +2982,7 @@ var _ = Describe("Resource excludes", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("[test_id:10254]VMI included, VM excluded: backup should fail", func() {
+			It("[test_id:10254]VMI included, VM excluded: empty backup without failure", func() {
 				By("Creating VirtualMachines")
 				vmSpec := newVMSpecBlankDVTemplate("test-vm", "100Mi")
 				_, err := framework.CreateVirtualMachineFromDefinition(f.KvClient, f.Namespace.Name, vmSpec)
@@ -2959,8 +3001,22 @@ var _ = Describe("Resource excludes", func() {
 				By("Creating backup")
 				err = framework.CreateBackupForNamespace(timeout, backupName, f.Namespace.Name, snapshotLocation, f.BackupNamespace, true)
 				Expect(err).ToNot(HaveOccurred())
-				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhasePartiallyFailed)
+				err = framework.WaitForBackupPhase(timeout, backupName, f.BackupNamespace, velerov1api.BackupPhaseCompleted)
 				Expect(err).ToNot(HaveOccurred())
+
+				By("Deleting VirtualMachineInstance")
+				err = framework.DeleteVirtualMachineInstance(f.KvClient, f.Namespace.Name, includedVMName)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating restore")
+				err = framework.CreateRestoreForBackup(timeout, backupName, restoreName, f.BackupNamespace, true)
+				Expect(err).ToNot(HaveOccurred())
+				err = framework.WaitForRestorePhase(timeout, restoreName, f.BackupNamespace, velerov1api.RestorePhaseCompleted)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying VMI not present")
+				_, err = framework.GetVirtualMachineInstance(f.KvClient, f.Namespace.Name, "test-vmi")
+				Expect(err).To(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: 

This Pull Request aims to update the backup process for VMIs so that when the VMI is owned by a VM excluded from the backup, we also exclude the VMI without triggering an error.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-45094

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bugfix: Ignore VMIs from backup when owner VM is excluded
```

