### PR TITLE
Allow skipping restore-specific checks during backup

### DIFF
--- a/pkg/plugin/vm_backup_item_action.go
+++ b/pkg/plugin/vm_backup_item_action.go
@@ -41,6 +41,12 @@ type VMBackupItemAction struct {
 	log logrus.FieldLogger
 }
 
+const (
+	// MetadataBackupLabel indicates that the object will be backed up for metadata purposes.
+	// This allows skipping restore and consistency-specific checks while ensuring the object is backed up.
+	MetadataBackupLabel = "velero.kubevirt.io/metadataBackup"
+)
+
 // NewVMBackupItemAction instantiates a VMBackupItemAction.
 func NewVMBackupItemAction(log logrus.FieldLogger) *VMBackupItemAction {
 	return &VMBackupItemAction{log: log}
@@ -81,22 +87,26 @@ func (p *VMBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backu
 		return nil, nil, fmt.Errorf("VM cannot be safely backed up")
 	}
 
-	skipVolume := func(volume kvcore.Volume) bool {
-		return volumeInDVTemplates(volume, vm)
-	}
-	restore, err := util.RestorePossible(vm.Spec.Template.Spec.Volumes, backup, vm.Namespace, skipVolume, p.log)
-	if err != nil {
-		return nil, nil, errors.WithStack(err)
-	}
-	if !restore {
-		return nil, nil, fmt.Errorf("VM would not be restored correctly")
+	// we can skip all checks that ensure consistency
+	// if we just want to backup for metadata purposes
+	if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
+		skipVolume := func(volume kvcore.Volume) bool {
+			return volumeInDVTemplates(volume, vm)
+		}
+
+		restore, err := util.RestorePossible(vm.Spec.Template.Spec.Volumes, backup, vm.Namespace, skipVolume, p.log)
+		if err != nil {
+			return nil, nil, errors.WithStack(err)
+		}
+		if !restore {
+			return nil, nil, fmt.Errorf("VM would not be restored correctly")
+		}
 	}
 
 	extra, err := kvgraph.NewVirtualMachineBackupGraph(vm)
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
-
 	return item, extra, nil
 }
 

--- a/pkg/plugin/vmi_backup_item_action.go
+++ b/pkg/plugin/vmi_backup_item_action.go
@@ -105,7 +105,7 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 
 	if isVMIOwned(vmi) {
 		util.AddAnnotation(item, AnnIsOwned, "true")
-	} else {
+	} else if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
 		restore, err := util.RestorePossible(vmi.Spec.Volumes, backup, vmi.Namespace, func(volume kvcore.Volume) bool { return false }, p.log)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
@@ -119,7 +119,6 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 	if err != nil {
 		return nil, nil, errors.WithStack(err)
 	}
-
 	return item, extra, nil
 }
 

--- a/pkg/plugin/vmi_backup_item_action_test.go
+++ b/pkg/plugin/vmi_backup_item_action_test.go
@@ -374,6 +374,41 @@ func TestVMIBackupItemAction(t *testing.T) {
 			"VM has DataVolume or PVC volumes and DataVolumes/PVCs is not included in the backup",
 			nullValidator,
 		},
+		{"Not owned VMI with DV volumes can exclude DataVolumes from backup when using metadataBackup label",
+			unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubevirt.io",
+					"kind":       "VirtualMachineInterface",
+					"metadata": map[string]interface{}{
+						"name":      "test-vmi",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"dataVolume": map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			velerov1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"velero.kubevirt.io/metadataBackup": "true",
+					},
+				},
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"datavolumes"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
 		{"Not owned VMI with PVC volumes must include PVCs in backup",
 			unstructured.Unstructured{
 				Object: map[string]interface{}{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This Pull Request aims to implement the `MetadataBackup` label, which allows to bypass restore-specific checks during backup.

This feature allows safely backing up resources such as VirtualMachines and VirtualMachineInstances even when restore conditions are not met, such as when DVs or PVCs are excluded from the backup.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirt-velero-plugin/issues/259
 
**Special notes for your reviewer**:

Feel free to discuss/oppose the annotation approach. I think this is the cleanest way to ignore restore checks for a specific object, but we may consider other alternatives. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow skipping restore-specific checks during backup
```

