### PR TITLE
Fix report of velero restores

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -476,7 +476,7 @@ func (r *KubernetesReporter) logBackups(kubeCli kubernetes.Interface) {
 }
 
 func (r *KubernetesReporter) logRestores(kubeCli kubernetes.Interface) {
-	r.dumpK8sEntityToFile(kubeCli, veleroRestore, fmt.Sprintf(veleroEntityUriTemplate, v1.NamespaceAll, veleroBackup))
+	r.dumpK8sEntityToFile(kubeCli, veleroRestore, fmt.Sprintf(veleroEntityUriTemplate, v1.NamespaceAll, veleroRestore))
 }
 
 func (r *KubernetesReporter) logVolumeSnapshots(kubeCli kubernetes.Interface) {


### PR DESCRIPTION
The dump function dumped backups also for restores

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

