### PR TITLE
MAC address cleanup

### DIFF
--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -71,6 +71,11 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 		vm.Spec.Running = nil
 	}
 
+	if util.ShouldClearMacAddress(input.Restore) {
+		p.log.Info("Clear virtual machine MAC addresses")
+		util.ClearMacAddress(&vm.Spec.Template.Spec)
+	}
+
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/pkg/plugin/vmi_restore_item_action.go
+++ b/pkg/plugin/vmi_restore_item_action.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	kvcore "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util/kvgraph"
 )
 
@@ -83,6 +84,11 @@ func (p *VMIRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) 
 	metadata, err := meta.Accessor(input.Item)
 	if err != nil {
 		return nil, err
+	}
+
+	if util.ShouldClearMacAddress(input.Restore) {
+		p.log.Info("Clear virtual machine instance MAC addresses")
+		util.ClearMacAddress(&vmi.Spec)
 	}
 
 	// Restricted labels must be cleared otherwise the VMI will be rejected.

--- a/pkg/plugin/vmi_restore_item_action_test.go
+++ b/pkg/plugin/vmi_restore_item_action_test.go
@@ -5,8 +5,10 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -50,6 +52,15 @@ func TestVmiRestoreExecute(t *testing.T) {
 						},
 					},
 				},
+				Restore: &velerov1.Restore{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-restore",
+						Namespace: "default",
+					},
+					Spec: velerov1.RestoreSpec{
+						IncludedNamespaces: []string{"default"},
+					},
+				},
 			},
 			false,
 			map[string]string{},
@@ -73,6 +84,15 @@ func TestVmiRestoreExecute(t *testing.T) {
 								"some.other/label":                    "test-value",
 							},
 						},
+					},
+				},
+				Restore: &velerov1.Restore{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-restore",
+						Namespace: "default",
+					},
+					Spec: velerov1.RestoreSpec{
+						IncludedNamespaces: []string{"default"},
 					},
 				},
 			},

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -32,6 +32,9 @@ const (
 	// RestoreRunStrategy indicates that the backed up VMs will be powered with the specified run strategy after restore.
 	RestoreRunStrategy = "velero.kubevirt.io/restore-run-strategy"
 
+	// ClearMacAddressLabel indicates that the MAC address should be cleared as part of the restore workflow.
+	ClearMacAddressLabel = "velero.kubevirt.io/clear-mac-address"
+
 	// VeleroExcludeLabel is used to exclude an object from Velero backups.
 	VeleroExcludeLabel = "velero.io/exclude-from-backup"
 )
@@ -327,4 +330,14 @@ func GetRestoreRunStrategy(restore *velerov1.Restore) (kvv1.VirtualMachineRunStr
 
 func IsMetadataBackup(backup *velerov1.Backup) bool {
 	return metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel)
+}
+
+func ShouldClearMacAddress(restore *velerov1.Restore) bool {
+	return metav1.HasLabel(restore.ObjectMeta, ClearMacAddressLabel)
+}
+
+func ClearMacAddress(vmiSpec *kvv1.VirtualMachineInstanceSpec) {
+	for i := 0; i < len(vmiSpec.Domain.Devices.Interfaces); i++ {
+		vmiSpec.Domain.Devices.Interfaces[i].MacAddress = ""
+	}
 }

--- a/tests/framework/backup.go
+++ b/tests/framework/backup.go
@@ -223,6 +223,10 @@ func CreateRestoreForBackup(ctx context.Context, backupName, restoreName, backup
 	return CreateRestoreWithLabels(ctx, backupName, restoreName, backupNamespace, wait, nil)
 }
 
+func CreateRestoreWithClearedMACAddress(ctx context.Context, backupName, restoreName, backupNamespace string, wait bool) error {
+	return CreateRestoreWithLabels(ctx, backupName, restoreName, backupNamespace, wait, map[string]string{"velero.kubevirt.io/clear-mac-address": "true"})
+}
+
 func GetRestore(ctx context.Context, restoreName string, backupNamespace string) (*v1.Restore, error) {
 	checkCMD := exec.CommandContext(ctx, veleroCLI, "restore", "get", "-n", backupNamespace, "-o", "json", restoreName)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When a virtual machine is restored to an alternate namespace, the virtual machine is restored with the same MAC address as the original one. This results in a MAC address conflict if the original virtual machine is still running on the original namespace.

Though we already have a work-in-progress PR, recent interest in this feature has forced us to open a new one to address this issue. From now on, users can optionally clean a VM or VMI MAC address by setting the `"velero.kubevirt.io/clear-mac-address"` label in the restore object.

Cherry-picked a couple of commits from https://github.com/kubevirt/kubevirt-velero-plugin/pull/235 to keep the original contributor's work.

/cc @esteban-ee

**Which issue(s) this PR fixes**:
Fixes #199

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support clearing MAC address by label
```

