### PR TITLE
Remove usage of deprecated .spec.running field

### DIFF
--- a/example/vm.yaml
+++ b/example/vm.yaml
@@ -19,7 +19,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/framework/vm.go
+++ b/tests/framework/vm.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -98,7 +99,6 @@ func CreateFedoraVmWithGuestAgent(vmName string, storageClassName string) *v1.Vi
 }
 
 func CreateVm(vmName string, storageClassName string, containerDiskUrl string, size string) *v1.VirtualMachine {
-	no := false
 	var zero int64 = 0
 	dataVolumeName := vmName + "-dv"
 
@@ -190,7 +190,7 @@ version: 2`
 			Name: vmName,
 		},
 		Spec: v1.VirtualMachineSpec{
-			Running: &no,
+			RunStrategy: ptr.To(v1.RunStrategyHalted),
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vmName,

--- a/tests/manifests/vm_for_hotplug.yaml
+++ b/tests/manifests/vm_for_hotplug.yaml
@@ -21,7 +21,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/manifests/vm_with_access_credentials.yaml
+++ b/tests/manifests/vm_with_access_credentials.yaml
@@ -21,7 +21,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/manifests/vm_with_clusterinstancetype_and_clusterpreference.yaml
+++ b/tests/manifests/vm_with_clusterinstancetype_and_clusterpreference.yaml
@@ -27,7 +27,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/manifests/vm_with_different_volume_types.yaml
+++ b/tests/manifests/vm_with_different_volume_types.yaml
@@ -21,7 +21,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/manifests/vm_with_dv_and_dvtemplate.yaml
+++ b/tests/manifests/vm_with_dv_and_dvtemplate.yaml
@@ -19,7 +19,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/manifests/vm_with_instancetype_and_preference.yaml
+++ b/tests/manifests/vm_with_instancetype_and_preference.yaml
@@ -27,7 +27,7 @@ spec:
         registry:
           pullMethod: node
           url: docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/manifests/vm_with_pvc.yaml
+++ b/tests/manifests/vm_with_pvc.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     a.test.label: included
 spec:
-  running: true
+  runStrategy: Always
   template:
     metadata:
       creationTimestamp: null

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -9,6 +9,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
 	kvv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
@@ -39,14 +41,13 @@ func PrintEvents(client kubecli.KubevirtClient, namespace, name string) {
 }
 
 var newVMSpecBlankDVTemplate = func(vmName, size string) *kvv1.VirtualMachine {
-	no := false
 	var zero int64 = 0
 	return &kvv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vmName,
 		},
 		Spec: kvv1.VirtualMachineSpec{
-			Running: &no,
+			RunStrategy: ptr.To(kvv1.RunStrategyHalted),
 			Template: &kvv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vmName,
@@ -112,14 +113,13 @@ var newVMSpecBlankDVTemplate = func(vmName, size string) *kvv1.VirtualMachine {
 }
 
 var newVMSpec = func(vmName, size string, volumeSource kvv1.VolumeSource) *kvv1.VirtualMachine {
-	no := false
 	var zero int64 = 0
 	return &kvv1.VirtualMachine{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: vmName,
 		},
 		Spec: kvv1.VirtualMachineSpec{
-			Running: &no,
+			RunStrategy: ptr.To(kvv1.RunStrategyHalted),
 			Template: &kvv1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: vmName,


### PR DESCRIPTION
The .spec.running field is deprecated, therefore we should runStrategy instread.

For more info, look at:
https://github.com/kubevirt/kubevirt/issues/11993

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

