### PR TITLE
Allow switching VM power state during restore 

### DIFF
--- a/pkg/plugin/vm_backup_item_action.go
+++ b/pkg/plugin/vm_backup_item_action.go
@@ -41,12 +41,6 @@ type VMBackupItemAction struct {
 	log logrus.FieldLogger
 }
 
-const (
-	// MetadataBackupLabel indicates that the object will be backed up for metadata purposes.
-	// This allows skipping restore and consistency-specific checks while ensuring the object is backed up.
-	MetadataBackupLabel = "velero.kubevirt.io/metadataBackup"
-)
-
 // NewVMBackupItemAction instantiates a VMBackupItemAction.
 func NewVMBackupItemAction(log logrus.FieldLogger) *VMBackupItemAction {
 	return &VMBackupItemAction{log: log}
@@ -89,7 +83,7 @@ func (p *VMBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backu
 
 	// we can skip all checks that ensure consistency
 	// if we just want to backup for metadata purposes
-	if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
+	if !util.IsMetadataBackup(backup) {
 		skipVolume := func(volume kvcore.Volume) bool {
 			return volumeInDVTemplates(volume, vm)
 		}
@@ -157,7 +151,7 @@ var isVMIExcludedByLabel = func(vm *kvcore.VirtualMachine) (bool, error) {
 		return false, nil
 	}
 
-	label, ok := labels[util.VELERO_EXCLUDE_LABEL]
+	label, ok := labels[util.VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 

--- a/pkg/plugin/vm_restore_item_action_test.go
+++ b/pkg/plugin/vm_restore_item_action_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -19,7 +21,7 @@ func TestVmRestoreExecute(t *testing.T) {
 					"name": "test-vm",
 				},
 				"spec": map[string]interface{}{
-					"running": true,
+					"runStrategy": "Always",
 					"dataVolumeTemplates": []map[string]interface{}{
 						{"metadata": map[string]interface{}{
 							"name": "test-dv-1",
@@ -49,6 +51,15 @@ func TestVmRestoreExecute(t *testing.T) {
 				},
 			},
 		},
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-restore",
+				Namespace: "default",
+			},
+			Spec: velerov1.RestoreSpec{
+				IncludedNamespaces: []string{"default"},
+			},
+		},
 	}
 
 	logrus.SetLevel(logrus.InfoLevel)
@@ -58,17 +69,52 @@ func TestVmRestoreExecute(t *testing.T) {
 		assert.Nil(t, err)
 
 		spec := output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
-		assert.Equal(t, true, spec["running"])
+		assert.Equal(t, "Always", spec["runStrategy"])
 	})
 
 	t.Run("Stopped VM should be restored stopped", func(t *testing.T) {
 		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
-		spec["running"] = false
+		spec["runStrategy"] = "Halted"
 		output, err := action.Execute(&input)
 		assert.Nil(t, err)
 
 		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
-		assert.Equal(t, false, spec["running"])
+		assert.Equal(t, "Halted", spec["runStrategy"])
+	})
+
+	t.Run("Stopped VM should be restored running when using appropriate label", func(t *testing.T) {
+		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
+		spec["runStrategy"] = "Halted"
+		input.Restore.Labels = map[string]string{"velero.kubevirt.io/restore-run-strategy": "Always"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
+		assert.Equal(t, "Always", spec["runStrategy"])
+	})
+
+	t.Run("Running VM should be restored stopped when using appropriate label", func(t *testing.T) {
+		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
+		spec["runStrategy"] = "Always"
+		input.Restore.Labels = map[string]string{"velero.kubevirt.io/restore-run-strategy": "Halted"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
+		assert.Equal(t, "Halted", spec["runStrategy"])
+	})
+
+	t.Run("Running field should be cleared when run strategy annotation", func(t *testing.T) {
+		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
+		spec["running"] = true
+		spec["runStrategy"] = ""
+		input.Restore.Labels = map[string]string{"velero.kubevirt.io/restore-run-strategy": "Halted"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
+		assert.Equal(t, "Halted", spec["runStrategy"])
+		assert.Nil(t, spec["running"])
 	})
 
 	t.Run("VM should return DVs as additional items", func(t *testing.T) {

--- a/pkg/plugin/vmi_backup_item_action.go
+++ b/pkg/plugin/vmi_backup_item_action.go
@@ -105,7 +105,7 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 
 	if isVMIOwned(vmi) {
 		util.AddAnnotation(item, AnnIsOwned, "true")
-	} else if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
+	} else if !util.IsMetadataBackup(backup) {
 		restore, err := util.RestorePossible(vmi.Spec.Volumes, backup, vmi.Namespace, func(volume kvcore.Volume) bool { return false }, p.log)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
@@ -156,7 +156,7 @@ var isVMExcludedByLabel = func(vmi *kvcore.VirtualMachineInstance) (bool, error)
 		return false, err
 	}
 
-	label, ok := vm.GetLabels()[util.VELERO_EXCLUDE_LABEL]
+	label, ok := vm.GetLabels()[util.VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 
@@ -174,6 +174,6 @@ func (p *VMIBackupItemAction) isPodExcludedByLabel(vmi *kvcore.VirtualMachineIns
 		return false, nil
 	}
 
-	label, ok := labels[util.VELERO_EXCLUDE_LABEL]
+	label, ok := labels[util.VeleroExcludeLabel]
 	return ok && label == "true", nil
 }

--- a/tests/framework/backup.go
+++ b/tests/framework/backup.go
@@ -189,7 +189,7 @@ func CreateSnapshotLocation(ctx context.Context, locationName, provider, region 
 	return nil
 }
 
-func CreateRestoreForBackup(ctx context.Context, backupName, restoreName string, backupNamespace string, wait bool) error {
+func CreateRestoreWithLabels(ctx context.Context, backupName, restoreName, backupNamespace string, wait bool, labels map[string]string) error {
 	args := []string{
 		"restore", "create", restoreName,
 		"--from-backup", backupName,
@@ -198,6 +198,13 @@ func CreateRestoreForBackup(ctx context.Context, backupName, restoreName string,
 
 	if wait {
 		args = append(args, "--wait")
+	}
+	if len(labels) > 0 {
+		labelPairs := []string{}
+		for key, value := range labels {
+			labelPairs = append(labelPairs, fmt.Sprintf("%s=%s", key, value))
+		}
+		args = append(args, "--labels", strings.Join(labelPairs, ","))
 	}
 
 	restoreCmd := exec.CommandContext(ctx, veleroCLI, args...)
@@ -210,6 +217,10 @@ func CreateRestoreForBackup(ctx context.Context, backupName, restoreName string,
 	}
 
 	return nil
+}
+
+func CreateRestoreForBackup(ctx context.Context, backupName, restoreName, backupNamespace string, wait bool) error {
+	return CreateRestoreWithLabels(ctx, backupName, restoreName, backupNamespace, wait, nil)
 }
 
 func GetRestore(ctx context.Context, restoreName string, backupNamespace string) (*v1.Restore, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This Pull Request enhances the behavior of VirtualMachine restores by introducing a new label:

    "velero.kubevirt.io/restore-run-strategy"


This label can be added to the restore resource to explicitly control the power state of the VirtualMachine during the restore process. The VirtualMachine's state is backed up as it exists at the time of backup, but these labels allow you to override the default behavior and define the desired RunStrategy at restore time.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubevirt/kubevirt-velero-plugin/issues/294

**Special notes for your reviewer**:

There's some overlapping code with https://github.com/kubevirt/kubevirt-velero-plugin/pull/304 but conflicts will be easy to solve.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow switching VM run strategy during restore 
```

