### PR TITLE
[release-0.7] Allow skipping restore-specific checks during backup

### DIFF
--- a/pkg/plugin/vm_backup_item_action_test.go
+++ b/pkg/plugin/vm_backup_item_action_test.go
@@ -8,6 +8,7 @@ import (
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	kvcore "kubevirt.io/api/core/v1"
@@ -316,6 +317,67 @@ func TestVMBackupAction(t *testing.T) {
 			}},
 			true,
 			[]velero.ResourceIdentifier{},
+		},
+		{"Action should succeed when VM with excluded volumes has metadataBackup label",
+			unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubevirt.io",
+					"kind":       "VirtualMachine",
+					"metadata": map[string]interface{}{
+						"name":      "test-vm",
+						"namespace": testNamespace,
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"volumes": []map[string]interface{}{
+									map[string]interface{}{
+										"name": "vol",
+										"dataVolume": map[string]interface{}{
+											"name": "test-dv",
+										},
+									},
+								},
+							},
+						},
+					},
+					"status": map[string]interface{}{
+						"created":         true,
+						"printableStatus": "Running",
+					},
+				},
+			},
+			v1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"velero.kubevirt.io/metadataBackup": "true",
+					},
+				},
+				Spec: v1.BackupSpec{
+					ExcludedResources: []string{"datavolumes", "persistentvolumeclaims"},
+					IncludedResources: []string{"virtualmachineinstances"},
+				},
+			},
+			false,
+			[]velero.ResourceIdentifier{
+				{
+					GroupResource: schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstances"},
+					Namespace:     testNamespace,
+					Name:          "test-vm",
+				},
+				// Our plugin still returns the PVC and DV even though they are excluded.
+				// Velero will filter them during backup.
+				{
+					GroupResource: schema.GroupResource{Group: "cdi.kubevirt.io", Resource: "datavolumes"},
+					Namespace:     testNamespace,
+					Name:          "test-dv",
+				},
+				{
+					GroupResource: kuberesource.PersistentVolumeClaims,
+					Namespace:     testNamespace,
+					Name:          "test-dv",
+				},
+			},
 		},
 		{"Created VM needs to include VMI",
 			unstructured.Unstructured{

--- a/pkg/plugin/vmi_backup_item_action.go
+++ b/pkg/plugin/vmi_backup_item_action.go
@@ -112,7 +112,7 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 		}
 
 		util.AddAnnotation(item, AnnIsOwned, "true")
-	} else {
+	} else if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
 		restore, err := util.RestorePossible(vmi.Spec.Volumes, backup, vmi.Namespace, func(volume kvcore.Volume) bool { return false }, p.log)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)

--- a/pkg/plugin/vmi_backup_item_action_test.go
+++ b/pkg/plugin/vmi_backup_item_action_test.go
@@ -368,6 +368,41 @@ func TestVMIBackupItemAction(t *testing.T) {
 			"VM has DataVolume or PVC volumes and DataVolumes/PVCs is not included in the backup",
 			nullValidator,
 		},
+		{"Not owned VMI with DV volumes can exclude DataVolumes from backup when using metadataBackup label",
+			unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "kubevirt.io",
+					"kind":       "VirtualMachineInterface",
+					"metadata": map[string]interface{}{
+						"name":      "test-vmi",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"volumes": []interface{}{
+							map[string]interface{}{
+								"dataVolume": map[string]interface{}{},
+							},
+						},
+					},
+				},
+			},
+			velerov1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"velero.kubevirt.io/metadataBackup": "true",
+					},
+				},
+				Spec: velerov1.BackupSpec{
+					ExcludedResources: []string{"datavolumes"},
+				},
+			},
+			launcherPod,
+			returnFalse,
+			returnFalse,
+			false,
+			"",
+			nullValidator,
+		},
 		{"Not owned VMI with PVC volumes must include PVCs in backup",
 			unstructured.Unstructured{
 				Object: map[string]interface{}{


### PR DESCRIPTION
**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/kubevirt-velero-plugin/pull/285. Had to address some conflicts with the VM object graph, no major issues during backport.

This is part of the features we want to get into oadp 1.4.2 as discussed offline (related to https://github.com/kubevirt/kubevirt-velero-plugin/issues/199#issuecomment-2518208250).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow skipping restore-specific checks during backup
```

