### PR TITLE
[release-0.7] Allow switching VM power state during restore

### DIFF
--- a/pkg/plugin/vm_backup_item_action.go
+++ b/pkg/plugin/vm_backup_item_action.go
@@ -42,12 +42,6 @@ type VMBackupItemAction struct {
 	log logrus.FieldLogger
 }
 
-const (
-	// MetadataBackupLabel indicates that the object will be backed up for metadata purposes.
-	// This allows skipping restore and consistency-specific checks while ensuring the object is backed up.
-	MetadataBackupLabel = "velero.kubevirt.io/metadataBackup"
-)
-
 // NewVMBackupItemAction instantiates a VMBackupItemAction.
 func NewVMBackupItemAction(log logrus.FieldLogger) *VMBackupItemAction {
 	return &VMBackupItemAction{log: log}
@@ -92,7 +86,7 @@ func (p *VMBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backu
 
 	// we can skip all checks that ensure consistency
 	// if we just want to backup for metadata purposes
-	if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
+	if !util.IsMetadataBackup(backup) {
 		skipVolume := func(volume kvcore.Volume) bool {
 			return volumeInDVTemplates(volume, vm)
 		}
@@ -227,7 +221,7 @@ var isVMIExcludedByLabel = func(vm *kvcore.VirtualMachine) (bool, error) {
 		return false, nil
 	}
 
-	label, ok := labels[util.VELERO_EXCLUDE_LABEL]
+	label, ok := labels[util.VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 

--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/ptr"
 	kvcore "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 )
 
 // VIMRestorePlugin is a VMI restore item action plugin for Velero (duh!)
@@ -61,6 +63,12 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 	vm := new(kvcore.VirtualMachine)
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), vm); err != nil {
 		return nil, errors.WithStack(err)
+	}
+
+	if runStrategy, ok := util.GetRestoreRunStrategy(input.Restore); ok {
+		p.log.Infof("Setting virtual machine run strategy to %s", runStrategy)
+		vm.Spec.RunStrategy = ptr.To(runStrategy)
+		vm.Spec.Running = nil
 	}
 
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)

--- a/pkg/plugin/vm_restore_item_action_test.go
+++ b/pkg/plugin/vm_restore_item_action_test.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	velerov1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -19,7 +21,7 @@ func TestVmRestoreExecute(t *testing.T) {
 					"name": "test-vm",
 				},
 				"spec": map[string]interface{}{
-					"running": true,
+					"runStrategy": "Always",
 					"dataVolumeTemplates": []map[string]interface{}{
 						{"metadata": map[string]interface{}{
 							"name": "test-dv-1",
@@ -33,6 +35,15 @@ func TestVmRestoreExecute(t *testing.T) {
 				},
 			},
 		},
+		Restore: &velerov1.Restore{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-restore",
+				Namespace: "default",
+			},
+			Spec: velerov1.RestoreSpec{
+				IncludedNamespaces: []string{"default"},
+			},
+		},
 	}
 
 	logrus.SetLevel(logrus.InfoLevel)
@@ -42,17 +53,52 @@ func TestVmRestoreExecute(t *testing.T) {
 		assert.Nil(t, err)
 
 		spec := output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
-		assert.Equal(t, true, spec["running"])
+		assert.Equal(t, "Always", spec["runStrategy"])
 	})
 
 	t.Run("Stopped VM should be restored stopped", func(t *testing.T) {
 		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
-		spec["running"] = false
+		spec["runStrategy"] = "Halted"
 		output, err := action.Execute(&input)
 		assert.Nil(t, err)
 
 		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
-		assert.Equal(t, false, spec["running"])
+		assert.Equal(t, "Halted", spec["runStrategy"])
+	})
+
+	t.Run("Stopped VM should be restored running when using appropriate label", func(t *testing.T) {
+		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
+		spec["runStrategy"] = "Halted"
+		input.Restore.Labels = map[string]string{"velero.kubevirt.io/restore-run-strategy": "Always"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
+		assert.Equal(t, "Always", spec["runStrategy"])
+	})
+
+	t.Run("Running VM should be restored stopped when using appropriate label", func(t *testing.T) {
+		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
+		spec["runStrategy"] = "Always"
+		input.Restore.Labels = map[string]string{"velero.kubevirt.io/restore-run-strategy": "Halted"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
+		assert.Equal(t, "Halted", spec["runStrategy"])
+	})
+
+	t.Run("Running field should be cleared when run strategy annotation", func(t *testing.T) {
+		spec := input.Item.UnstructuredContent()["spec"].(map[string]interface{})
+		spec["running"] = true
+		spec["runStrategy"] = ""
+		input.Restore.Labels = map[string]string{"velero.kubevirt.io/restore-run-strategy": "Halted"}
+		output, err := action.Execute(&input)
+		assert.Nil(t, err)
+
+		spec = output.UpdatedItem.UnstructuredContent()["spec"].(map[string]interface{})
+		assert.Equal(t, "Halted", spec["runStrategy"])
+		assert.Nil(t, spec["running"])
 	})
 
 	t.Run("VM should return DVs as additional items", func(t *testing.T) {

--- a/pkg/plugin/vmi_backup_item_action.go
+++ b/pkg/plugin/vmi_backup_item_action.go
@@ -112,7 +112,7 @@ func (p *VMIBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 		}
 
 		util.AddAnnotation(item, AnnIsOwned, "true")
-	} else if !metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel) {
+	} else if !util.IsMetadataBackup(backup) {
 		restore, err := util.RestorePossible(vmi.Spec.Volumes, backup, vmi.Namespace, func(volume kvcore.Volume) bool { return false }, p.log)
 		if err != nil {
 			return nil, nil, errors.WithStack(err)
@@ -148,7 +148,7 @@ var isVMExcludedByLabel = func(vmi *kvcore.VirtualMachineInstance) (bool, error)
 		return false, err
 	}
 
-	label, ok := vm.GetLabels()[util.VELERO_EXCLUDE_LABEL]
+	label, ok := vm.GetLabels()[util.VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 
@@ -166,7 +166,7 @@ func (p *VMIBackupItemAction) isPodExcludedByLabel(vmi *kvcore.VirtualMachineIns
 		return false, nil
 	}
 
-	label, ok := labels[util.VELERO_EXCLUDE_LABEL]
+	label, ok := labels[util.VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,7 +27,17 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
-const VELERO_EXCLUDE_LABEL = "velero.io/exclude-from-backup"
+const (
+	// MetadataBackupLabel indicates that the object will be backed up for metadata purposes.
+	// This allows skipping restore and consistency-specific checks while ensuring the object is backed up.
+	MetadataBackupLabel = "velero.kubevirt.io/metadataBackup"
+
+	// RestoreRunStrategy indicates that the backed up VMs will be powered with the specified run strategy after restore.
+	RestoreRunStrategy = "velero.kubevirt.io/restore-run-strategy"
+
+	// VeleroExcludeLabel is used to exclude an object from Velero backups.
+	VeleroExcludeLabel = "velero.io/exclude-from-backup"
+)
 
 func GetK8sClient() (*kubernetes.Clientset, error) {
 	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
@@ -180,7 +190,7 @@ var IsDVExcludedByLabel = func(namespace, dvName string) (bool, error) {
 		return false, nil
 	}
 
-	label, ok := labels[VELERO_EXCLUDE_LABEL]
+	label, ok := labels[VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 
@@ -201,7 +211,7 @@ var IsPVCExcludedByLabel = func(namespace, pvcName string) (bool, error) {
 		return false, nil
 	}
 
-	label, ok := labels[VELERO_EXCLUDE_LABEL]
+	label, ok := labels[VeleroExcludeLabel]
 	return ok && label == "true", nil
 }
 
@@ -363,5 +373,15 @@ func AddVMIObjectGraph(spec v1.VirtualMachineInstanceSpec, namespace string, ext
 	extra = addAccessCredentials(spec.AccessCredentials, namespace, extra, log)
 
 	return extra
+}
 
+func GetRestoreRunStrategy(restore *velerov1.Restore) (kvv1.VirtualMachineRunStrategy, bool) {
+	if metav1.HasLabel(restore.ObjectMeta, RestoreRunStrategy) {
+		return kvv1.VirtualMachineRunStrategy(restore.Labels[RestoreRunStrategy]), true
+	}
+	return "", false
+}
+
+func IsMetadataBackup(backup *velerov1.Backup) bool {
+	return metav1.HasLabel(backup.ObjectMeta, MetadataBackupLabel)
 }

--- a/tests/framework/backup.go
+++ b/tests/framework/backup.go
@@ -267,7 +267,7 @@ func CreateSnapshotLocation(ctx context.Context, locationName, provider, region 
 	return nil
 }
 
-func CreateRestoreForBackup(ctx context.Context, backupName, restoreName string, backupNamespace string, wait bool) error {
+func CreateRestoreWithLabels(ctx context.Context, backupName, restoreName, backupNamespace string, wait bool, labels map[string]string) error {
 	args := []string{
 		"restore", "create", restoreName,
 		"--from-backup", backupName,
@@ -276,6 +276,13 @@ func CreateRestoreForBackup(ctx context.Context, backupName, restoreName string,
 
 	if wait {
 		args = append(args, "--wait")
+	}
+	if len(labels) > 0 {
+		labelPairs := []string{}
+		for key, value := range labels {
+			labelPairs = append(labelPairs, fmt.Sprintf("%s=%s", key, value))
+		}
+		args = append(args, "--labels", strings.Join(labelPairs, ","))
 	}
 
 	restoreCmd := exec.CommandContext(ctx, veleroCLI, args...)
@@ -288,6 +295,10 @@ func CreateRestoreForBackup(ctx context.Context, backupName, restoreName string,
 	}
 
 	return nil
+}
+
+func CreateRestoreForBackup(ctx context.Context, backupName, restoreName, backupNamespace string, wait bool) error {
+	return CreateRestoreWithLabels(ctx, backupName, restoreName, backupNamespace, wait, nil)
 }
 
 func GetRestore(ctx context.Context, restoreName string, backupNamespace string) (*v1.Restore, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/kubevirt-velero-plugin/pull/306. Just had to address some conflicts with the vm object graph code, no major issues.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirt-velero-plugin/issues/294

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow switching VM run strategy during restore 
```

