### PR TITLE
fix: update permissions for build-all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,12 +122,12 @@ shell: build-dirs
 		-u $$(id -u):$$(id -g) \
 		$(PODMAN_SPECIFIC_FLAG) \
 		-v "$$(pwd)/_output/bin:/output:delegated" \
-		-v $$(pwd)/.go/pkg:/go/pkg \
-		-v $$(pwd)/.go/src:/go/src \
-		-v $$(pwd)/.go/std:/go/std \
-		-v $$(pwd)/.go/bin:/go/bin \
-		-v $$(pwd):/go/src/kubevirt-velero-plugin \
-		-v $$(pwd)/.go/std/$(GOOS)_$(GOARCH):/usr/local/go/pkg/$(GOOS)_$(GOARCH)_static \
+		-v $$(pwd)/.go/pkg:/go/pkg:Z \
+		-v $$(pwd)/.go/src:/go/src:Z \
+		-v $$(pwd)/.go/std:/go/std:Z \
+		-v $$(pwd)/.go/bin:/go/bin:Z \
+		-v $$(pwd):/go/src/kubevirt-velero-plugin:Z \
+		-v $$(pwd)/.go/std/$(GOOS)_$(GOARCH):/usr/local/go/pkg/$(GOOS)_$(GOARCH)_static:Z \
 		-v "$$(pwd)/.go/go-build:/.cache/go-build:delegated" \
 		-e CGO_ENABLED=0 \
 		-w /go/src/kubevirt-velero-plugin \


### PR DESCRIPTION
The permissions for executing the hack/build/build.sh script were not set correctly.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

