### PR TITLE
[release-v0.7] Generate new firmware UUID during restore

### DIFF
--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -76,6 +76,11 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 		util.ClearMacAddress(&vm.Spec.Template.Spec)
 	}
 
+	if util.ShouldGenerateNewFirmwareUUID(input.Restore) {
+		p.log.Info("Generate new firmware UUID")
+		util.GenerateNewFirmwareUUID(&vm.Spec.Template.Spec, vm.Name, vm.Namespace, string(vm.UID))
+	}
+
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/pkg/plugin/vmi_restore_item_action.go
+++ b/pkg/plugin/vmi_restore_item_action.go
@@ -90,6 +90,11 @@ func (p *VMIRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) 
 		util.ClearMacAddress(&vmi.Spec)
 	}
 
+	if util.ShouldGenerateNewFirmwareUUID(input.Restore) {
+		p.log.Info("Generate new firmware UUID")
+		util.GenerateNewFirmwareUUID(&vmi.Spec, vmi.Name, vmi.Namespace, string(vmi.UID))
+	}
+
 	// Restricted labels must be cleared otherwise the VMI will be rejected.
 	// The restricted labels contain runtime information about the underlying KVM object.
 	labels := removeRestrictedLabels(vmi.GetLabels())

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -19,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	kvv1 "kubevirt.io/api/core/v1"
@@ -37,6 +39,9 @@ const (
 
 	// ClearMacAddressLabel indicates that the MAC address should be cleared as part of the restore workflow.
 	ClearMacAddressLabel = "velero.kubevirt.io/clear-mac-address"
+
+	// GenerateNewFirmwareUUIDLabel indicates that a new firmware UUID should be generated for VMs as part of the restore workflow.
+	GenerateNewFirmwareUUIDLabel = "velero.kubevirt.io/generate-new-firmware-uuid"
 
 	// VeleroExcludeLabel is used to exclude an object from Velero backups.
 	VeleroExcludeLabel = "velero.io/exclude-from-backup"
@@ -397,4 +402,16 @@ func ClearMacAddress(vmiSpec *kvv1.VirtualMachineInstanceSpec) {
 	for i := 0; i < len(vmiSpec.Domain.Devices.Interfaces); i++ {
 		vmiSpec.Domain.Devices.Interfaces[i].MacAddress = ""
 	}
+}
+
+func ShouldGenerateNewFirmwareUUID(restore *velerov1.Restore) bool {
+	return metav1.HasLabel(restore.ObjectMeta, GenerateNewFirmwareUUIDLabel)
+}
+
+// GenerateNewFirmwareUUID generates a new random firmware UUID for the restored VM
+func GenerateNewFirmwareUUID(vmiSpec *kvv1.VirtualMachineInstanceSpec, name, namespace, uid string) {
+	if vmiSpec.Domain.Firmware == nil {
+		vmiSpec.Domain.Firmware = &kvv1.Firmware{}
+	}
+	vmiSpec.Domain.Firmware.UUID = types.UID(uuid.New().String())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Manual backport of https://github.com/kubevirt/kubevirt-velero-plugin/pull/317, just had to address one conflict in a unit test. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/kubevirt-velero-plugin/issues/199#issuecomment-2466301398

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add label to optionally generate new firmware UUID during restore
```

