### PR TITLE
Include VMI's datavolume  type  in restore graph 

### DIFF
--- a/pkg/util/kvgraph/util.go
+++ b/pkg/util/kvgraph/util.go
@@ -72,9 +72,9 @@ func addVolumeGraph(vmiSpec v1.VirtualMachineInstanceSpec, vmName, namespace str
 		switch {
 		case volume.DataVolume != nil:
 			resources = addVeleroResource(volume.DataVolume.Name, namespace, "datavolumes", resources)
-			if isBackup {
+			// if isBackup {
 				resources = addVeleroResource(volume.DataVolume.Name, namespace, "persistentvolumeclaims", resources)
-			}
+			// }
 		case volume.PersistentVolumeClaim != nil:
 			resources = addVeleroResource(volume.PersistentVolumeClaim.ClaimName, namespace, "persistentvolumeclaims", resources)
 		case volume.MemoryDump != nil:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
We always shoud include 



**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
https://issues.redhat.com/browse/OADP-5608

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

