### PR TITLE
Improve instance type and preference functional test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ velero-v*
 
 .go
 .idea
-
+.cache
 _ci-configs

--- a/tests/manifests/cluster-preference.yaml
+++ b/tests/manifests/cluster-preference.yaml
@@ -4,4 +4,4 @@ metadata:
   name: test-vm-preference
 spec:
   cpu:
-    preferredCPUTopology: "preferSockets"
+    preferredCPUTopology: "sockets"

--- a/tests/manifests/preference.yaml
+++ b/tests/manifests/preference.yaml
@@ -4,4 +4,4 @@ metadata:
   name: test-vm-preference
 spec:
   cpu:
-    preferredCPUTopology: "preferSockets"
+    preferredCPUTopology: "sockets"


### PR DESCRIPTION
**What this PR does / why we need it**:

This change ensures copies of the original ControllerRevisions are
retained and used to assert that they are referenced by the VM after it
is restored.

The underlying instance type and preference objects are also updated and
further assertions made about the eventual VirtualMachineInstance to
ensure the original revision of these objects is used.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

