### PR TITLE
Improve handling of vmStateStorageClass

### DIFF
--- a/hack/cluster-deploy-prerequisites.sh
+++ b/hack/cluster-deploy-prerequisites.sh
@@ -49,14 +49,6 @@ until _kubectl wait -n kubevirt kv kubevirt --for condition=Available --timeout 
     sleep 1m
 done
 
-# Get the default storage class to patch vmStateStorageClass
-# TODO: Improve vmStateStorageClass handling
-DEFAULT_STORAGE_CLASS=$(_kubectl get storageclass -o jsonpath='{.items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")].metadata.name}')
-if [ -n "$DEFAULT_STORAGE_CLASS" ]; then
-    # Patch kubevirt with VM state storage class
-    _kubectl patch -n kubevirt kubevirt kubevirt --type merge -p '{"spec": {"configuration": { "vmStateStorageClass": "'$DEFAULT_STORAGE_CLASS'" }}}'
-fi
-
 # Patch kubevirt with hotplug and persistent VM state feature gate enabled
 _kubectl patch -n kubevirt kubevirt kubevirt --type merge -p '{"spec": {"configuration": { "developerConfiguration": { "featureGates": ["HotplugVolumes", "VMPersistentState"] }}}}'
 

--- a/tests/vm_backup_test.go
+++ b/tests/vm_backup_test.go
@@ -309,6 +309,9 @@ var _ = Describe("[smoke] VM Backup", func() {
 	})
 
 	It("VM with backend storage PVC should be backed up and restored appropriately", func() {
+		By("Updating VM state storage class")
+		framework.UpdateVMStateStorageClass(f.KvClient)
+
 		By("Creating a VM with backend storage PVC")
 		var err error
 		vm = framework.CreateVmWithGuestAgent("test-vm", f.StorageClass)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Tests using `vmStateStorageClass` may fail downstream in clusters where the default storage class lacks snapshot support. An optimal solution would be to use a default storage class that supports snapshots downstream, as backup and restore functionalities depend on it. That said, attempting to use KV_STORAGE_CLASS and updating the kubevirt spec will fix the issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://issues.redhat.com/browse/CNV-57363

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

