### PR TITLE
NO-JIRA: v0.7: go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module kubevirt.io/kubevirt-velero-plugin
 go 1.22.3
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/onsi/ginkgo/v2 v2.17.1
 	github.com/onsi/gomega v1.32.0
 	github.com/pkg/errors v0.9.1
@@ -42,7 +43,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/pprof v0.0.0-20230602150820-91b7bce49751 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/go-hclog v0.14.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.0 // indirect


### PR DESCRIPTION
Update go.mod to support switch from Cachito to Hermeto (Cachi2).

[Replacing Cachito with Hermeto (formerly known as Cachi2)](https://spaces.redhat.com/pages/viewpage.action?pageId=591269742)

While switching should "Just Work" :TM: , it is not always seemless and we've discovered a discrepancy using Hermeto to deliver sources to fail because an attempt is made to download files during hermetic build.

 - [Failing scratch build](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=67206344) without change
 - [Slack thread (comment)](https://redhat-internal.slack.com/archives/C02AX10EQJW/p1743699832886149?thread_ts=1743628332.968749&cid=C02AX10EQJW)
 - [Successful scratch build](https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=67228718) with change

