### PR TITLE
Add OADP maintainers to kubevirt-plugin

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -8,6 +8,8 @@ aliases:
       - mhenriks
       - ShellyKa13
       - alromeros
+      - sseago
+      - shubham-pampattiwar
   code-reviewers:
       - tbaransk
       - aglitke
@@ -17,3 +19,5 @@ aliases:
       - ShellyKa13
       - brybacki
       - alromeros
+      - sseago
+      - shubham-pampattiwar


### PR DESCRIPTION
OADP needs some representation here to help keep branches up to date, bug fix and feature development.
Adding two OADP maintainers, Scott and Shubham.

WDYT?
