### PR TITLE
Do not skip PVC when building VMIs resaources graph during restore item action.

### DIFF
--- a/pkg/plugin/vm_restore_item_action_test.go
+++ b/pkg/plugin/vm_restore_item_action_test.go
@@ -141,8 +141,10 @@ func TestVmRestoreExecute(t *testing.T) {
 		output, _ := action.Execute(&input)
 
 		dvs := output.AdditionalItems
-		assert.Equal(t, 2, len(dvs))
+		assert.Equal(t, 4, len(dvs))
 		assert.Equal(t, "test-dv-1", dvs[0].Name)
-		assert.Equal(t, "test-dv-2", dvs[1].Name)
+		assert.Equal(t, "test-dv-1", dvs[1].Name)
+		assert.Equal(t, "test-dv-2", dvs[2].Name)
+		assert.Equal(t, "test-dv-2", dvs[3].Name)
 	})
 }

--- a/pkg/util/kvgraph/backup_graph.go
+++ b/pkg/util/kvgraph/backup_graph.go
@@ -82,7 +82,7 @@ func NewVirtualMachineBackupGraph(vm *v1.VirtualMachine) ([]velero.ResourceIdent
 		}
 	}
 
-	resources, err = addCommonVMIObjectGraph(vm.Spec.Template.Spec, vm.GetName(), namespace, true, resources)
+	resources, err = addCommonVMIObjectGraph(vm.Spec.Template.Spec, vm.GetName(), namespace, resources)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -104,7 +104,7 @@ func NewVirtualMachineInstanceBackupGraph(vmi *v1.VirtualMachineInstance) ([]vel
 		errs = append(errs, err)
 	}
 
-	resources, err = addCommonVMIObjectGraph(vmi.Spec, vmi.GetName(), vmi.GetNamespace(), true, resources)
+	resources, err = addCommonVMIObjectGraph(vmi.Spec, vmi.GetName(), vmi.GetNamespace(), resources)
 	if err != nil {
 		errs = append(errs, err)
 	}

--- a/pkg/util/kvgraph/restore_graph.go
+++ b/pkg/util/kvgraph/restore_graph.go
@@ -59,10 +59,10 @@ func NewVirtualMachineRestoreGraph(vm *v1.VirtualMachine) ([]velero.ResourceIden
 	if vm.Spec.Preference != nil {
 		resources = addPreferenceType(*vm.Spec.Preference, vm.GetNamespace(), resources)
 	}
-	return addCommonVMIObjectGraph(vm.Spec.Template.Spec, vm.GetName(), vm.GetNamespace(), false, resources)
+	return addCommonVMIObjectGraph(vm.Spec.Template.Spec, vm.GetName(), vm.GetNamespace(), resources)
 }
 
 // NewVirtualMachineInstanceRestoreGraph returns the restore object graph for a specific VMI
 func NewVirtualMachineInstanceRestoreGraph(vmi *v1.VirtualMachineInstance) ([]velero.ResourceIdentifier, error) {
-	return addCommonVMIObjectGraph(vmi.Spec, vmi.GetName(), vmi.GetNamespace(), false, []velero.ResourceIdentifier{})
+	return addCommonVMIObjectGraph(vmi.Spec, vmi.GetName(), vmi.GetNamespace(), []velero.ResourceIdentifier{})
 }

--- a/pkg/util/kvgraph/restore_graph_test.go
+++ b/pkg/util/kvgraph/restore_graph_test.go
@@ -249,6 +249,11 @@ func TestNewVirtualMachineRestoreGraph(t *testing.T) {
 				{
 					GroupResource: schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"},
 					Namespace:     "",
+					Name:          "test-datavolume",
+				},
+				{
+					GroupResource: schema.GroupResource{Group: "", Resource: "persistentvolumeclaims"},
+					Namespace:     "",
 					Name:          "backend-pvc",
 				},
 				{
@@ -361,6 +366,11 @@ func TestNewVirtualMachineInstanceRestoreGraph(t *testing.T) {
 					},
 					Namespace: "test-namespace",
 					Name:      "test-dv",
+				},
+				{
+					GroupResource: kuberesource.PersistentVolumeClaims,
+					Namespace:     "test-namespace",
+					Name:          "test-dv",
 				},
 				{
 					GroupResource: kuberesource.PersistentVolumeClaims,

--- a/pkg/util/kvgraph/util.go
+++ b/pkg/util/kvgraph/util.go
@@ -61,20 +61,18 @@ func addVeleroResource(name, namespace, resource string, resources []velero.Reso
 	return resources
 }
 
-func addCommonVMIObjectGraph(spec v1.VirtualMachineInstanceSpec, vmName, namespace string, isBackup bool, resources []velero.ResourceIdentifier) ([]velero.ResourceIdentifier, error) {
-	resources, err := addVolumeGraph(spec, vmName, namespace, isBackup, resources)
+func addCommonVMIObjectGraph(spec v1.VirtualMachineInstanceSpec, vmName, namespace string, resources []velero.ResourceIdentifier) ([]velero.ResourceIdentifier, error) {
+	resources, err := addVolumeGraph(spec, vmName, namespace, resources)
 	resources = addAccessCredentials(spec.AccessCredentials, namespace, resources)
 	return resources, err
 }
 
-func addVolumeGraph(vmiSpec v1.VirtualMachineInstanceSpec, vmName, namespace string, isBackup bool, resources []velero.ResourceIdentifier) ([]velero.ResourceIdentifier, error) {
+func addVolumeGraph(vmiSpec v1.VirtualMachineInstanceSpec, vmName, namespace string, resources []velero.ResourceIdentifier) ([]velero.ResourceIdentifier, error) {
 	for _, volume := range vmiSpec.Volumes {
 		switch {
 		case volume.DataVolume != nil:
 			resources = addVeleroResource(volume.DataVolume.Name, namespace, "datavolumes", resources)
-			if isBackup {
-				resources = addVeleroResource(volume.DataVolume.Name, namespace, "persistentvolumeclaims", resources)
-			}
+			resources = addVeleroResource(volume.DataVolume.Name, namespace, "persistentvolumeclaims", resources)
 		case volume.PersistentVolumeClaim != nil:
 			resources = addVeleroResource(volume.PersistentVolumeClaim.ClaimName, namespace, "persistentvolumeclaims", resources)
 		case volume.MemoryDump != nil:


### PR DESCRIPTION
In order to restore one or more Virtual Machines out of many  in the SAME namespace, velero offers restoring by resource label.
When using a label selector, any resource not including the restore label are excluded by velero.
That might include other resources that are quieted for the VM, such as datavolumes and PVCs.
In order to resolve this,  we already  include any additional required resource in a graph which is return to velero for backup/restore even if those resources do not include matching label.

With this PR we are removing a condition results in excluding PVC for datavolume type VM volume from the graph, and a the datavolume pending for ever for the existence of the associated PVC after restore.

fixes issue: https://issues.redhat.com/browse/OADP-5608


How to test?
Deploy  the following VM, with DataVolume type volume and a label.
```
$ kubectl create namespace test-vm
```
```
apiVersion: kubevirt.io/v1
kind: VirtualMachine
metadata:
  labels:
    app: test-vm-1
  name: test-vm-1
  namespace: test-vm
spec:
  dataVolumeTemplates:
  - metadata:
      annotations:
        cdi.kubevirt.io/storage.deleteAfterCompletion: "false"
      creationTimestamp: null
      name: test-vm-1-dv
    spec:
      pvc:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 150Mi
        volumeMode: Block
      source:
        registry:
          pullMethod: node
          url: docker://quay.io/kubevirt/cirros-container-disk-demo
  running: true
  template:
    metadata:
      creationTimestamp: null
      name: test-vm-1
    spec:
      architecture: amd64
      domain:
        devices:
          disks:
          - disk:
              bus: virtio
            name: volume0
          interfaces:
          - masquerade: {}
            name: default
          rng: {}
        machine:
          type: q35
        resources:
          requests:
            memory: 256M
      networks:
      - name: default
        pod: {}
      terminationGracePeriodSeconds: 0
      volumes:
      - dataVolume:
          name: test-vm-1-dv
        name: volume0

```
```
$ velero backup create test-vm-backup --include-namespaces=test-vm
```
```
$ kubectl delete namespace/test-vm
```
```
$ velero restore create restore --from-backup=test-vm-backup --selector=app=test-vm-1
```
```
# The DataVolume and the PVC are included in the restore:

$ velero restore describe restore --details
Name:         restore
Namespace:    openshift-adp
Labels:       <none>
Annotations:  <none>

Phase:                       Completed
Total items to be restored:  7
Items restored:              7

Started:    2025-04-15 12:47:34 +0000 UTC
Completed:  2025-04-15 12:47:45 +0000 UTC

Backup:  test-vm-backup

Namespaces:
  Included:  all namespaces found in the backup
  Excluded:  <none>

Resources:
  Included:        *
  Excluded:        nodes, events, events.events.k8s.io, backups.velero.io, restores.velero.io, resticrepositories.velero.io, csinodes.storage.k8s.io, volumeattachments.storage.k8s.io, backuprepositories.velero.io
  Cluster-scoped:  auto

Namespace mappings:  <none>

Label selector:  app=test-vm-1

Or label selector:  <none>

Restore PVs:  auto

CSI Snapshot Restores:
  test-vm/test-vm-1-dv:
    Snapshot:
      Snapshot Content Name: 869720b2434ab00b3947a8811a1d62d3c427a389ae14d6b7edc5ebf4ada6c1dc
      Storage Snapshot ID: 0001-0011-openshift-storage-0000000000000002-6e885852-eacd-4673-8c04-ed000af1ff7c
      CSI Driver: openshift-storage.rbd.csi.ceph.com

Existing Resource Policy:   <none>
ItemOperationTimeout:       4h0m0s

Preserve Service NodePorts:  auto

Uploader config:


HooksAttempted:   0
HooksFailed:      0

Resource List:
  cdi.kubevirt.io/v1beta1/DataVolume:
    - test-vm/test-vm-1-dv(created)
  kubevirt.io/v1/VirtualMachine:
    - test-vm/test-vm-1(created)
  snapshot.storage.k8s.io/v1/VolumeSnapshot:
    - test-vm/velero-test-vm-1-dv-jp4jt(created)
  snapshot.storage.k8s.io/v1/VolumeSnapshotContent:
    - snapcontent-9765a149-df9b-4882-aa46-7783b012f5c2(created)
  v1/Namespace:
    - test-vm(created)
  v1/PersistentVolume:
    - pvc-19e9056b-c772-433b-8f46-5cc3d97f65f5(skipped)
  v1/PersistentVolumeClaim:
    - test-vm/test-vm-1-dv(created)
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
FixBug: Include PVC in restore VM graph so it will be included even when using label selector that would exclude it.
```

