### PR TITLE
kvgraph: Remove instance type and preference objects from graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ velero-v*
 .go
 .idea
 .cache
+.config
 _ci-configs

--- a/pkg/plugin/vm_backup_item_action_test.go
+++ b/pkg/plugin/vm_backup_item_action_test.go
@@ -536,19 +536,9 @@ func TestVMBackupAction(t *testing.T) {
 			false,
 			[]velero.ResourceIdentifier{
 				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachineinstancetypes"},
-					Namespace:     testNamespace,
-					Name:          "test-instancetype",
-				},
-				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
 					Namespace:     testNamespace,
 					Name:          "test-revision1",
-				},
-				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachinepreferences"},
-					Namespace:     testNamespace,
-					Name:          "test-preference",
 				},
 				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},

--- a/pkg/util/kvgraph/backup_graph_test.go
+++ b/pkg/util/kvgraph/backup_graph_test.go
@@ -256,19 +256,9 @@ func TestNewVirtualMachineBackupGraph(t *testing.T) {
 			getVM(true, false),
 			[]velero.ResourceIdentifier{
 				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachineinstancetypes"},
-					Namespace:     "",
-					Name:          "test-instancetype",
-				},
-				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
 					Namespace:     "",
 					Name:          "controller-revision-instancetype",
-				},
-				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachinepreferences"},
-					Namespace:     "",
-					Name:          "test-preference",
 				},
 				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
@@ -306,19 +296,9 @@ func TestNewVirtualMachineBackupGraph(t *testing.T) {
 			getVM(false, false),
 			[]velero.ResourceIdentifier{
 				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachineinstancetypes"},
-					Namespace:     "",
-					Name:          "test-instancetype",
-				},
-				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
 					Namespace:     "",
 					Name:          "controller-revision-instancetype",
-				},
-				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachinepreferences"},
-					Namespace:     "",
-					Name:          "test-preference",
 				},
 				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
@@ -346,19 +326,9 @@ func TestNewVirtualMachineBackupGraph(t *testing.T) {
 			getVM(true, true),
 			[]velero.ResourceIdentifier{
 				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachineinstancetypes"},
-					Namespace:     "",
-					Name:          "test-instancetype",
-				},
-				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
 					Namespace:     "",
 					Name:          "controller-revision-instancetype",
-				},
-				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachinepreferences"},
-					Namespace:     "",
-					Name:          "test-preference",
 				},
 				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},

--- a/pkg/util/kvgraph/restore_graph_test.go
+++ b/pkg/util/kvgraph/restore_graph_test.go
@@ -222,19 +222,9 @@ func TestNewVirtualMachineRestoreGraph(t *testing.T) {
 			getVM(true, true),
 			[]velero.ResourceIdentifier{
 				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachineinstancetypes"},
-					Namespace:     "",
-					Name:          "test-instancetype",
-				},
-				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},
 					Namespace:     "",
 					Name:          "controller-revision-instancetype",
-				},
-				{
-					GroupResource: schema.GroupResource{Group: "instancetype.kubevirt.io", Resource: "virtualmachinepreferences"},
-					Namespace:     "",
-					Name:          "test-preference",
 				},
 				{
 					GroupResource: schema.GroupResource{Group: "apps", Resource: "controllerrevisions"},

--- a/pkg/util/kvgraph/util.go
+++ b/pkg/util/kvgraph/util.go
@@ -21,7 +21,6 @@ package kvgraph
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/vmware-tanzu/velero/pkg/kuberesource"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
@@ -36,18 +35,14 @@ const (
 
 // KVObjectGraph represents the graph of objects that can be potentially related to a KubeVirt resource
 var KVObjectGraph = map[string]schema.GroupResource{
-	"virtualmachineinstances":            {Group: "kubevirt.io", Resource: "virtualmachineinstances"},
-	"virtualmachineinstancetypes":        {Group: "instancetype.kubevirt.io", Resource: "virtualmachineinstancetypes"},
-	"virtualmachineclusterinstancetypes": {Group: "instancetype.kubevirt.io", Resource: "virtualmachineclusterinstancetypes"},
-	"virtualmachinepreferences":          {Group: "instancetype.kubevirt.io", Resource: "virtualmachinepreferences"},
-	"virtualmachineclusterpreferences":   {Group: "instancetype.kubevirt.io", Resource: "virtualmachineclusterpreferences"},
-	"datavolumes":                        {Group: "cdi.kubevirt.io", Resource: "datavolumes"},
-	"controllerrevisions":                {Group: "apps", Resource: "controllerrevisions"},
-	"configmaps":                         {Group: "", Resource: "configmaps"},
-	"persistentvolumeclaims":             kuberesource.PersistentVolumeClaims,
-	"serviceaccounts":                    kuberesource.ServiceAccounts,
-	"secrets":                            kuberesource.Secrets,
-	"pods":                               kuberesource.Pods,
+	"virtualmachineinstances": {Group: "kubevirt.io", Resource: "virtualmachineinstances"},
+	"datavolumes":             {Group: "cdi.kubevirt.io", Resource: "datavolumes"},
+	"controllerrevisions":     {Group: "apps", Resource: "controllerrevisions"},
+	"configmaps":              {Group: "", Resource: "configmaps"},
+	"persistentvolumeclaims":  kuberesource.PersistentVolumeClaims,
+	"serviceaccounts":         kuberesource.ServiceAccounts,
+	"secrets":                 kuberesource.Secrets,
+	"pods":                    kuberesource.Pods,
 }
 
 func addVeleroResource(name, namespace, resource string, resources []velero.ResourceIdentifier) []velero.ResourceIdentifier {
@@ -129,12 +124,6 @@ func addPreference(vm *v1.VirtualMachine, resources []velero.ResourceIdentifier)
 }
 
 func addInstanceTypeMatcherResource(matcher v1.Matcher, statusRef *v1.InstancetypeStatusRef, namespace string, resources []velero.ResourceIdentifier) []velero.ResourceIdentifier {
-	switch resource := strings.ToLower(matcher.GetKind()) + "s"; resource {
-	case "virtualmachineclusterinstancetypes", "virtualmachineclusterpreferences":
-		resources = addVeleroResource(matcher.GetName(), "", resource, resources)
-	case "virtualmachineinstancetypes", "virtualmachinepreferences":
-		resources = addVeleroResource(matcher.GetName(), namespace, resource, resources)
-	}
 	if statusRef != nil && statusRef.ControllerRevisionRef != nil {
 		resources = addVeleroResource(statusRef.ControllerRevisionRef.Name, namespace, "controllerrevisions", resources)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

These objects do not need to be captured as part of the graph as we
already capture point in time copies within controller revisions that
are already included.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

I've also included a tiny chore commit adding `.config` to `.gitignore` after getting frustrated with kubevirtci (?) leftovers being picked up.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Instance type and preference referenced by a VirtualMachine objects are no longer captured and restored by the plugin. Only the required ControllerRevision copies of these objects are captured and restored avoiding any conflicts on restore into a target cluster with differing generations etc of these resources.
```

