### PR TITLE
E2E tests: sleep before:  WaitForVirtualMachineStatus, allowing informer

### DIFF
--- a/tests/framework/vm.go
+++ b/tests/framework/vm.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
 	k8sv1 "k8s.io/api/core/v1"
@@ -392,7 +393,7 @@ func WaitForVirtualMachineStatus(client kubecli.KubevirtClient, namespace, name 
 		for _, status := range statuses {
 			if vm.Status.PrintableStatus == status {
 				ginkgo.By(fmt.Sprintf(" got %s", status))
-
+				time.Sleep(5*time.Second)
 				return true, nil
 			}
 		}


### PR DESCRIPTION
Sometimes, during restore, we observed the VM is not restored.
thought i only got the skip because already exit message once,
suspect  client's informer's case was not updated before trying to restore the vm, causing velero to skip it.




<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

