### PR TITLE
Skip E2E tests using  test/manifest/ Manifests files requesting VolumeMode Block and not supported by the Storage-class

### DIFF
--- a/tests/framework/storage.go
+++ b/tests/framework/storage.go
@@ -3,6 +3,7 @@ package framework
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -366,4 +367,130 @@ func EventuallyDVWith(kvClient kubecli.KubevirtClient, namespace, name string, t
 		Expect(err).ToNot(HaveOccurred())
 		return pvc != nil && pvc.Spec.VolumeName != ""
 	}, timeoutSec, time.Second).Should(BeTrue())
+}
+
+// IsVolumeModeBlockSupported checks if a given storage class supports provisioning
+// block mode PersistentVolumes. It does this by creating a temporary PVC that
+// requests block mode and observing the results.
+//
+// Parameters:
+//   - kvClient: An initialized KubeVirt clientset.
+//   - namespace: The namespace where the test PVC will be created.
+//   - storageClassName: The name of the StorageClass to test. If this string is
+//     empty, the function will test the cluster's default StorageClass.
+//
+// Returns:
+//   - (bool): True if block mode is supported, false otherwise.
+//   - (error): An error if the check is inconclusive due to an unexpected
+//     issue (e.g., insufficient capacity), or if a Kubernetes API error occurs.
+func IsVolumeModeBlockSupported(kvClient kubecli.KubevirtClient, namespace string, storageClassName string) (bool, error) {
+	// Generate a unique name for our test PVC to avoid collisions.
+	pvcName := fmt.Sprintf("block-support-check-%d", time.Now().UnixNano())
+	blockMode := v1.PersistentVolumeBlock
+
+	// Define the test PVC manifest.
+	testPVC := &v1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pvcName,
+			Namespace: namespace,
+		},
+		Spec: v1.PersistentVolumeClaimSpec{
+			// Explicitly request a raw block device.
+			VolumeMode: &blockMode,
+			AccessModes: []v1.PersistentVolumeAccessMode{
+				v1.ReadWriteOnce,
+			},
+			Resources: v1.VolumeResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+
+	// If a storageClassName is provided, add it to the spec.
+	// Otherwise, the default SC will be used.
+	if storageClassName != "" {
+		testPVC.Spec.StorageClassName = &storageClassName
+	}
+
+	ginkgo.By(fmt.Sprintf("Creating test PVC '%s' to check for block support", pvcName))
+	_, err := kvClient.CoreV1().PersistentVolumeClaims(namespace).Create(context.TODO(), testPVC, metav1.CreateOptions{})
+	if err != nil {
+		return false, fmt.Errorf("failed to create test PVC %s: %w", pvcName, err)
+	}
+
+	// IMPORTANT: Defer the cleanup to ensure the test PVC is always deleted.
+	defer func() {
+		ginkgo.By(fmt.Sprintf("Cleaning up test PVC '%s'", pvcName))
+		err := kvClient.CoreV1().PersistentVolumeClaims(namespace).Delete(context.TODO(), pvcName, metav1.DeleteOptions{})
+		if err != nil && !errors.IsNotFound(err) {
+			// Log the cleanup failure but don't fail the test on it.
+			fmt.Fprintf(ginkgo.GinkgoWriter, "Warning: failed to delete test PVC %s: %v\n", pvcName, err)
+		}
+	}()
+
+	// Poll for a definitive result (Bound or ProvisioningFailed) for a shorter duration.
+	var lastEventMessage string
+	pollErr := wait.PollImmediate(3*time.Second, 30*time.Second, func() (bool, error) {
+		pvc, err := kvClient.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), pvcName, metav1.GetOptions{})
+		if err != nil {
+			return false, fmt.Errorf("failed to get test PVC %s: %w", pvcName, err)
+		}
+
+		if pvc.Status.Phase == v1.ClaimBound {
+			// Found a definitive success. Stop polling.
+			return true, nil
+		}
+		
+		// Check for a definitive failure event.
+		events, err := kvClient.CoreV1().Events(namespace).List(context.TODO(), metav1.ListOptions{
+			FieldSelector: fmt.Sprintf("involvedObject.kind=PersistentVolumeClaim,involvedObject.name=%s", pvcName),
+		})
+		if err != nil {
+			// Don't fail the poll on a transient event list error.
+			fmt.Fprintf(ginkgo.GinkgoWriter, "Warning: could not list events for PVC %s: %v\n", pvcName, err)
+			return false, nil
+		}
+
+		for _, event := range events.Items {
+			if event.Type == v1.EventTypeWarning && event.Reason == "ProvisioningFailed" {
+				// Found a definitive failure. Stop polling.
+				lastEventMessage = event.Message
+				return true, nil 
+			}
+		}
+
+		// No definitive result yet, continue polling.
+		return false, nil
+	})
+
+
+	// --- Analyze the results of the poll ---
+
+	if pollErr == nil {
+		// Poll stopped because we found a definitive result.
+		if lastEventMessage == "" {
+			// If message is empty, it means we must have found a 'Bound' PVC.
+			ginkgo.By(fmt.Sprintf("Test PVC '%s' successfully bound. Block mode is supported.", pvcName))
+			return true, nil
+		}
+
+		// We found a ProvisioningFailed event. Now check the message.
+		if strings.Contains(strings.ToLower(lastEventMessage), "block volume is not supported") {
+			ginkgo.By("Found 'ProvisioningFailed' event: Block mode is not supported.")
+			return false, nil
+		} else {
+			return false, fmt.Errorf("provisioning failed for an inconclusive reason: %s", lastEventMessage)
+		}
+	}
+	
+	if pollErr == wait.ErrWaitTimeout {
+		// The poll timed out without any specific error. Assume it's a slow cluster and that block is supported.
+		ginkgo.By("PVC check timed out without specific errors, assuming block mode is supported.")
+		return true, nil
+	}
+
+	// An unexpected error occurred during polling.
+	return false, fmt.Errorf("error while polling for PVC status: %w", pollErr)
 }


### PR DESCRIPTION
e2e tests: Skip tests requiring block volumes on unsupported storage
Problem:

Several  manifests in test/manifests request PersistentVolumes with volumeMode: Block. When these tests using those are run on a storage provider that does not support block volumes (such as GCP Filestore), the tests fail during the initial setup because the PVC cannot be provisioned. This results in test failures that are due to environment incompatibility, not a bug in the code.

Solution:

This change introduces a helper function that runs before a resource is created from a manifest.

The function first checks the manifest file to see if it requests volumeMode: Block.
If it does, it then verifies whether the current StorageClass supports block volume provisioning.
If block mode is required but not supported, the test is now cleanly skipped with an informative message.
This ensures the test suite produces more accurate results when run across storage backends with different capabilities.