### PR TITLE
Tests: Fix ignored error in CreateStartedVirtualMachine helper

### DIFF
--- a/tests/framework/vm.go
+++ b/tests/framework/vm.go
@@ -245,7 +245,7 @@ func CreateVirtualMachineFromDefinition(client kubecli.KubevirtClient, namespace
 }
 
 func CreateStartedVirtualMachine(client kubecli.KubevirtClient, namespace string, vmSpec *v1.VirtualMachine) (*v1.VirtualMachine, error) {
-	vm, err := CreateVirtualMachineFromDefinition(client, namespace, vmSpec)
+	_, err := CreateVirtualMachineFromDefinition(client, namespace, vmSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -256,9 +256,7 @@ func CreateStartedVirtualMachine(client kubecli.KubevirtClient, namespace string
 		return nil, err
 	}
 
-	vm, err = WaitVirtualMachineRunning(client, namespace, vmSpec.Name, vmSpec.Spec.DataVolumeTemplates[0].Name)
-
-	return vm, nil
+	return WaitVirtualMachineRunning(client, namespace, vmSpec.Name, vmSpec.Spec.DataVolumeTemplates[0].Name)
 }
 
 func WaitVirtualMachineRunning(client kubecli.KubevirtClient, namespace, vmName, dvName string) (*v1.VirtualMachine, error) {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This PR fixes an issue in the `CreateStartedVirtualMachine` helper used in functional tests.

Previously, the function ignored the final error return value, which led to nil pointer dereferences when the function failed but returned nil resources. We've been seeing some of these nil ptrs dereferences in D/S runs.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

