### PR TITLE
e2e: update tests with multi arch images

### DIFF
--- a/tests/framework/pod.go
+++ b/tests/framework/pod.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	busyboxImage = "quay.io/quay/busybox:latest"
+	busyboxImage = "quay.io/prometheus/busybox:latest"
 )
 
 func PodWithPvcSpec(podName, pvcName string, cmd, args []string) *v1.Pod {

--- a/tests/framework/vm.go
+++ b/tests/framework/vm.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	alpineUrl               = "docker://quay.io/kubevirt/alpine-container-disk-demo:v0.57.1"
+	alpineUrl               = "docker://quay.io/kubevirt/alpine-container-disk-demo:v1.6.0"
 	alpineWithGuestAgentUrl = "docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1"
-	fedoraWithGuestAgentUrl = "docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk"
+	fedoraWithGuestAgentUrl = "docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.6.0"
 )
 
 // DISKS for VMS

--- a/tests/manifests/vm_with_access_credentials.yaml
+++ b/tests/manifests/vm_with_access_credentials.yaml
@@ -20,7 +20,7 @@ spec:
       source:
         registry:
           pullMethod: node
-          url: docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk
+          url: docker://quay.io/kubevirt/fedora-with-test-tooling-container-disk:v1.6.0
   runStrategy: Always
   template:
     metadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
e2e tests are failing on s390x platform because of test images are not multi arch, so updating test images with multi arch images which will support for all x86,arm,s390x platform

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

