### PR TITLE
Tests: Prevent nil pointer dereference during VM deletion

### DIFF
--- a/tests/vm_backup_test.go
+++ b/tests/vm_backup_test.go
@@ -62,9 +62,11 @@ var _ = Describe("[smoke] VM Backup", func() {
 			}
 		}
 
-		err := framework.DeleteVirtualMachine(f.KvClient, f.Namespace.Name, vm.Name)
-		if err != nil {
-			fmt.Fprintf(GinkgoWriter, "Err: %s\n", err)
+		if vm != nil {
+			err := framework.DeleteVirtualMachine(f.KvClient, f.Namespace.Name, vm.Name)
+			if err != nil {
+				fmt.Fprintf(GinkgoWriter, "Err: %s\n", err)
+			}
 		}
 
 		cancelFunc()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

When a test fails during VM creation/start, the vm global variable remains nil, which leads to a nil pointer dereference in the after-each. This PR ensures that the VM is only deleted if the variable is non-nil.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

