### PR TITLE
Tests: Replace Update() calls with Patch()

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -25,6 +25,7 @@ import (
 	kv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
+	"kubevirt.io/kubevirt-velero-plugin/tests/patch"
 )
 
 const (
@@ -493,12 +494,14 @@ func (r *KubernetesReporter) logVolumeSnapshotContents(kubeCli kubernetes.Interf
 
 func UpdateVMStateStorageClass(kvClient kubecli.KubevirtClient) {
 	kv := GetKubevirt(kvClient)
-	kv.Spec.Configuration.VMStateStorageClass = getStorageClassFromEnv()
+	storageClass := getStorageClassFromEnv()
 
-	data, err := json.Marshal(kv.Spec)
+	patchData, err := patch.New(
+		patch.WithReplace("/spec/configuration/vmStateStorageClass", storageClass),
+	).GeneratePayload()
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
-	patchData := fmt.Sprintf(`[{ "op": "replace", "path": "/spec", "value": %s }]`, string(data))
-	_, err = kvClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
+
+	_, err = kvClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 }
 

--- a/tests/framework/vm.go
+++ b/tests/framework/vm.go
@@ -63,6 +63,7 @@ func NewDataVolumeForBlankRawImage(dataVolumeName, size string, storageClass str
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        dataVolumeName,
 			Annotations: map[string]string{},
+			Labels:      map[string]string{},
 		},
 		Spec: cdiv1.DataVolumeSpec{
 			Source: &cdiv1.DataVolumeSource{

--- a/tests/patch/patch.go
+++ b/tests/patch/patch.go
@@ -1,0 +1,94 @@
+package patch
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+type PatchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+// ~ is encoded as ~0 and / is encoded as ~1 (RFC 6901)
+func EscapeJSONPointer(s string) string {
+	s = strings.ReplaceAll(s, "~", "~0")
+	s = strings.ReplaceAll(s, "/", "~1")
+	return s
+}
+
+func LabelPath(key string) string {
+	return "/metadata/labels/" + EscapeJSONPointer(key)
+}
+
+func AnnotationPath(key string) string {
+	return "/metadata/annotations/" + EscapeJSONPointer(key)
+}
+
+type Builder struct {
+	operations []PatchOperation
+}
+
+type Option func(*Builder)
+
+func New(opts ...Option) *Builder {
+	b := &Builder{
+		operations: []PatchOperation{},
+	}
+	for _, opt := range opts {
+		opt(b)
+	}
+	return b
+}
+
+func WithAdd(path string, value interface{}) Option {
+	return func(b *Builder) {
+		b.operations = append(b.operations, PatchOperation{
+			Op:    "add",
+			Path:  path,
+			Value: value,
+		})
+	}
+}
+
+func WithReplace(path string, value interface{}) Option {
+	return func(b *Builder) {
+		b.operations = append(b.operations, PatchOperation{
+			Op:    "replace",
+			Path:  path,
+			Value: value,
+		})
+	}
+}
+
+func WithRemove(path string) Option {
+	return func(b *Builder) {
+		b.operations = append(b.operations, PatchOperation{
+			Op:   "remove",
+			Path: path,
+		})
+	}
+}
+
+func WithAddLabel(key, value string, existingLabels map[string]string) Option {
+	if existingLabels == nil {
+		return WithAdd("/metadata/labels", map[string]string{key: value})
+	}
+	return WithAdd(LabelPath(key), value)
+}
+
+func WithAddAnnotation(key, value string, existingAnnotations map[string]string) Option {
+	if existingAnnotations == nil {
+		return WithAdd("/metadata/annotations", map[string]string{key: value})
+	}
+	return WithAdd(AnnotationPath(key), value)
+}
+
+func (b *Builder) GeneratePayload() ([]byte, error) {
+	if len(b.operations) == 0 {
+		return nil, fmt.Errorf("no patch operations defined")
+	}
+	return json.Marshal(b.operations)
+}

--- a/tests/patch/patch_test.go
+++ b/tests/patch/patch_test.go
@@ -1,0 +1,238 @@
+package patch
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeJSONPointer(t *testing.T) {
+	result := EscapeJSONPointer("key~with/slash")
+	assert.Equal(t, "key~0with~1slash", result)
+}
+
+func TestLabelPath(t *testing.T) {
+	path := LabelPath("example.com/key")
+	assert.Equal(t, "/metadata/labels/example.com~1key", path)
+}
+
+func TestAnnotationPath(t *testing.T) {
+	path := AnnotationPath("example.com/annotation")
+	assert.Equal(t, "/metadata/annotations/example.com~1annotation", path)
+}
+
+func TestNew(t *testing.T) {
+	t.Run("creates builder with no operations", func(t *testing.T) {
+		builder := New()
+		assert.NotNil(t, builder)
+		assert.Empty(t, builder.operations)
+	})
+
+	t.Run("creates builder with options", func(t *testing.T) {
+		builder := New(
+			WithAdd("/metadata/labels/key", "value"),
+			WithReplace("/spec/replicas", 3),
+		)
+		assert.NotNil(t, builder)
+		assert.Len(t, builder.operations, 2)
+	})
+}
+
+func TestWithAdd(t *testing.T) {
+	t.Run("adds operation with string value", func(t *testing.T) {
+		builder := New(WithAdd("/metadata/labels/env", "production"))
+
+		assert.Len(t, builder.operations, 1)
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/labels/env", builder.operations[0].Path)
+		assert.Equal(t, "production", builder.operations[0].Value)
+	})
+
+	t.Run("adds operation with numeric value", func(t *testing.T) {
+		builder := New(WithAdd("/spec/replicas", 5))
+
+		assert.Len(t, builder.operations, 1)
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/spec/replicas", builder.operations[0].Path)
+		assert.Equal(t, 5, builder.operations[0].Value)
+	})
+
+	t.Run("adds operation with map value", func(t *testing.T) {
+		labels := map[string]string{"key": "value"}
+		builder := New(WithAdd("/metadata/labels", labels))
+
+		assert.Len(t, builder.operations, 1)
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/labels", builder.operations[0].Path)
+		assert.Equal(t, labels, builder.operations[0].Value)
+	})
+}
+
+func TestWithReplace(t *testing.T) {
+	t.Run("replaces with string value", func(t *testing.T) {
+		builder := New(WithReplace("/spec/template/spec/image", "nginx:latest"))
+
+		assert.Len(t, builder.operations, 1)
+		assert.Equal(t, "replace", builder.operations[0].Op)
+		assert.Equal(t, "/spec/template/spec/image", builder.operations[0].Path)
+		assert.Equal(t, "nginx:latest", builder.operations[0].Value)
+	})
+
+	t.Run("replaces with boolean value", func(t *testing.T) {
+		builder := New(WithReplace("/spec/running", true))
+
+		assert.Len(t, builder.operations, 1)
+		assert.Equal(t, "replace", builder.operations[0].Op)
+		assert.Equal(t, "/spec/running", builder.operations[0].Path)
+		assert.Equal(t, true, builder.operations[0].Value)
+	})
+}
+
+func TestWithRemove(t *testing.T) {
+	t.Run("removes operation without value", func(t *testing.T) {
+		builder := New(WithRemove("/metadata/annotations/old-key"))
+
+		assert.Len(t, builder.operations, 1)
+		assert.Equal(t, "remove", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/annotations/old-key", builder.operations[0].Path)
+		assert.Nil(t, builder.operations[0].Value)
+	})
+}
+
+func TestGeneratePayload(t *testing.T) {
+	t.Run("returns error for empty operations", func(t *testing.T) {
+		builder := New()
+		payload, err := builder.GeneratePayload()
+
+		assert.Nil(t, payload)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "no patch operations defined")
+	})
+
+	t.Run("generates valid JSON for single operation", func(t *testing.T) {
+		builder := New(WithAdd("/metadata/labels/app", "myapp"))
+		payload, err := builder.GeneratePayload()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, payload)
+
+		var operations []PatchOperation
+		err = json.Unmarshal(payload, &operations)
+		assert.NoError(t, err)
+		assert.Len(t, operations, 1)
+
+		assert.Equal(t, "add", operations[0].Op)
+		assert.Equal(t, "/metadata/labels/app", operations[0].Path)
+		assert.Equal(t, "myapp", operations[0].Value)
+	})
+
+	t.Run("generates valid JSON for multiple operations", func(t *testing.T) {
+		builder := New(
+			WithAdd("/metadata/labels/env", "prod"),
+			WithReplace("/spec/replicas", float64(3)),
+			WithRemove("/metadata/annotations/deprecated"),
+		)
+		payload, err := builder.GeneratePayload()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, payload)
+
+		var operations []PatchOperation
+		err = json.Unmarshal(payload, &operations)
+		assert.NoError(t, err)
+		assert.Len(t, operations, 3)
+
+		assert.Equal(t, "add", operations[0].Op)
+		assert.Equal(t, "/metadata/labels/env", operations[0].Path)
+		assert.Equal(t, "prod", operations[0].Value)
+
+		assert.Equal(t, "replace", operations[1].Op)
+		assert.Equal(t, "/spec/replicas", operations[1].Path)
+		assert.Equal(t, float64(3), operations[1].Value)
+
+		assert.Equal(t, "remove", operations[2].Op)
+		assert.Equal(t, "/metadata/annotations/deprecated", operations[2].Path)
+		assert.Nil(t, operations[2].Value)
+	})
+
+	t.Run("generates valid JSON with complex value", func(t *testing.T) {
+		complexValue := map[string]interface{}{
+			"cpu":    "2",
+			"memory": "4Gi",
+		}
+		builder := New(WithReplace("/spec/resources", complexValue))
+		payload, err := builder.GeneratePayload()
+
+		assert.NoError(t, err)
+		assert.NotNil(t, payload)
+
+		var operations []PatchOperation
+		err = json.Unmarshal(payload, &operations)
+		assert.NoError(t, err)
+		assert.Len(t, operations, 1)
+
+		assert.Equal(t, "replace", operations[0].Op)
+		assert.Equal(t, "/spec/resources", operations[0].Path)
+
+		valueMap, ok := operations[0].Value.(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "2", valueMap["cpu"])
+		assert.Equal(t, "4Gi", valueMap["memory"])
+	})
+}
+
+func TestBuilderChaining(t *testing.T) {
+	t.Run("can chain multiple options", func(t *testing.T) {
+		builder := New(
+			WithAdd("/metadata/labels/new", "label"),
+			WithReplace("/metadata/labels/existing", "updated"),
+			WithRemove("/metadata/labels/old"),
+			WithAdd("/spec/replicas", float64(5)),
+		)
+
+		assert.Len(t, builder.operations, 4)
+
+		payload, err := builder.GeneratePayload()
+		assert.NoError(t, err)
+
+		var operations []PatchOperation
+		err = json.Unmarshal(payload, &operations)
+		assert.NoError(t, err)
+		assert.Len(t, operations, 4)
+	})
+}
+
+func TestWithAddLabel(t *testing.T) {
+	t.Run("creates labels map when nil", func(t *testing.T) {
+		builder := New(WithAddLabel("app", "myapp", nil))
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/labels", builder.operations[0].Path)
+		assert.Equal(t, map[string]string{"app": "myapp"}, builder.operations[0].Value)
+	})
+
+	t.Run("adds specific label when labels exist", func(t *testing.T) {
+		existingLabels := map[string]string{"existing": "value"}
+		builder := New(WithAddLabel("app", "myapp", existingLabels))
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/labels/app", builder.operations[0].Path)
+		assert.Equal(t, "myapp", builder.operations[0].Value)
+	})
+}
+
+func TestWithAddAnnotation(t *testing.T) {
+	t.Run("creates annotations map when nil", func(t *testing.T) {
+		builder := New(WithAddAnnotation("desc", "test", nil))
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/annotations", builder.operations[0].Path)
+		assert.Equal(t, map[string]string{"desc": "test"}, builder.operations[0].Value)
+	})
+
+	t.Run("adds specific annotation when annotations exist", func(t *testing.T) {
+		existingAnnotations := map[string]string{"existing": "value"}
+		builder := New(WithAddAnnotation("desc", "test", existingAnnotations))
+		assert.Equal(t, "add", builder.operations[0].Op)
+		assert.Equal(t, "/metadata/annotations/desc", builder.operations[0].Path)
+		assert.Equal(t, "test", builder.operations[0].Value)
+	})
+}

--- a/tests/pvc_vs_labeling_test.go
+++ b/tests/pvc_vs_labeling_test.go
@@ -9,6 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	velerov1api "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/strings/slices"
 
@@ -16,6 +17,7 @@ import (
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 	"kubevirt.io/kubevirt-velero-plugin/tests/framework"
 	. "kubevirt.io/kubevirt-velero-plugin/tests/framework/matcher"
+	"kubevirt.io/kubevirt-velero-plugin/tests/patch"
 )
 
 var _ = Describe("PVC and VolumeSnapshot Labeling", func() {
@@ -63,11 +65,11 @@ var _ = Describe("PVC and VolumeSnapshot Labeling", func() {
 			pvc, err := framework.FindPVC(f.K8sClient, f.Namespace.Name, pvcName)
 			Expect(err).ToNot(HaveOccurred())
 
-			if pvc.Labels == nil {
-				pvc.Labels = make(map[string]string)
-			}
-			pvc.Labels[util.PVCUIDLabel] = userDefinedValue
-			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Update(context.Background(), pvc, metav1.UpdateOptions{})
+			patchData, err := patch.New(
+				patch.WithAddLabel(util.PVCUIDLabel, userDefinedValue, pvc.Labels),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Patch(context.Background(), pvc.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Creating backup")

--- a/tests/resource_filtering_test.go
+++ b/tests/resource_filtering_test.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/utils/strings/slices"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt-velero-plugin/tests/framework"
+	"kubevirt.io/kubevirt-velero-plugin/tests/patch"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,6 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	kvv1 "kubevirt.io/api/core/v1"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 	. "kubevirt.io/kubevirt-velero-plugin/tests/framework/matcher"
@@ -2606,55 +2608,67 @@ var _ = Describe("Resource excludes", func() {
 	})
 
 	Context("Exclude label", func() {
-		addExcludeLabel := func(labels map[string]string) map[string]string {
-			if labels == nil {
-				labels = make(map[string]string)
-			}
-			labels["velero.io/exclude-from-backup"] = "true"
-			return labels
-		}
-
 		addExcludeLabelToDV := func(name string) {
-			updateFunc := func(dataVolume *cdiv1.DataVolume) *cdiv1.DataVolume {
-				dataVolume.SetLabels(addExcludeLabel(dataVolume.GetLabels()))
-				return dataVolume
-			}
+			dv, err := framework.FindDataVolume(f.KvClient, f.Namespace.Name, name)
+			Expect(err).ToNot(HaveOccurred())
 
-			retryOnceOnErr(updateDataVolume(f.KvClient, f.Namespace.Name, name, updateFunc)).Should(BeNil())
+			patchData, err := patch.New(
+				patch.WithAddLabel(velerov1api.ExcludeFromBackupLabel, "true", dv.Labels),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = f.KvClient.CdiClient().CdiV1beta1().DataVolumes(f.Namespace.Name).Patch(context.TODO(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		}
 
 		addExcludeLabelToPVC := func(name string) {
-			update := func(pvc *v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim {
-				pvc.SetLabels(addExcludeLabel(pvc.GetLabels()))
-				return pvc
-			}
-			retryOnceOnErr(updatePvc(f.K8sClient, f.Namespace.Name, name, update)).Should(BeNil())
+			pvc, err := framework.FindPVC(f.K8sClient, f.Namespace.Name, name)
+			Expect(err).ToNot(HaveOccurred())
+
+			patchData, err := patch.New(
+				patch.WithAddLabel(velerov1api.ExcludeFromBackupLabel, "true", pvc.Labels),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = f.K8sClient.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Patch(context.TODO(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		}
 
 		addExcludeLabelToVMI := func(name string) {
-			update := func(vmi *kvv1.VirtualMachineInstance) *kvv1.VirtualMachineInstance {
-				vmi.SetLabels(addExcludeLabel(vmi.GetLabels()))
-				return vmi
-			}
-			retryOnceOnErr(updateVmi(f.KvClient, f.Namespace.Name, name, update)).Should(BeNil())
+			vmi, err := f.KvClient.VirtualMachineInstance(f.Namespace.Name).Get(context.Background(), name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			patchData, err := patch.New(
+				patch.WithAddLabel(velerov1api.ExcludeFromBackupLabel, "true", vmi.Labels),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = f.KvClient.VirtualMachineInstance(f.Namespace.Name).Patch(context.Background(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		}
 
 		addExcludeLabelToVM := func(name string) {
-			update := func(vm *kvv1.VirtualMachine) *kvv1.VirtualMachine {
-				vm.SetLabels(addExcludeLabel(vm.GetLabels()))
-				return vm
-			}
-			retryOnceOnErr(updateVm(f.KvClient, f.Namespace.Name, name, update)).Should(BeNil())
+			vm, err := f.KvClient.VirtualMachine(f.Namespace.Name).Get(context.Background(), name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			patchData, err := patch.New(
+				patch.WithAddLabel(velerov1api.ExcludeFromBackupLabel, "true", vm.Labels),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = f.KvClient.VirtualMachine(f.Namespace.Name).Patch(context.Background(), name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		}
 
 		addExcludeLabelToLauncherPodForVM := func(vmName string) {
-			retryOnceOnErr(
-				func() error {
-					pod := framework.FindLauncherPod(f.K8sClient, f.Namespace.Name, vmName)
-					pod.SetLabels(addExcludeLabel(pod.GetLabels()))
-					_, err := f.K8sClient.CoreV1().Pods(f.Namespace.Name).Update(context.TODO(), &pod, metav1.UpdateOptions{})
-					return err
-				}).Should(BeNil())
+			pod := framework.FindLauncherPod(f.K8sClient, f.Namespace.Name, vmName)
+			patchData, err := patch.New(
+				patch.WithAddLabel(velerov1api.ExcludeFromBackupLabel, "true", pod.Labels),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = f.K8sClient.CoreV1().Pods(f.Namespace.Name).Patch(context.TODO(), pod.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 		}
 
 		Context("Standalone DV", func() {
@@ -3454,70 +3468,6 @@ func addExpectedPVs(client *kubernetes.Clientset, namespace string, resources ma
 		pvs = append(pvs, pvName)
 	}
 	resources["PersistentVolume"] = pvs
-}
-
-func updateVm(kvClient kubecli.KubevirtClient, namespace string, name string,
-	update func(*kvv1.VirtualMachine) *kvv1.VirtualMachine) func() error {
-	return func() error {
-		vm, err := kvClient.VirtualMachine(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		vm = update(vm)
-
-		_, err = kvClient.VirtualMachine(namespace).Update(context.Background(), vm, metav1.UpdateOptions{})
-		return err
-	}
-}
-
-func updateVmi(kvClient kubecli.KubevirtClient, namespace string, name string,
-	update func(*kvv1.VirtualMachineInstance) *kvv1.VirtualMachineInstance) func() error {
-	return func() error {
-		vmi, err := kvClient.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		vmi = update(vmi)
-
-		_, err = kvClient.VirtualMachineInstance(namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
-		return err
-	}
-}
-
-func updatePvc(client *kubernetes.Clientset, namespace string, name string,
-	update func(*v1.PersistentVolumeClaim) *v1.PersistentVolumeClaim) func() error {
-	return func() error {
-		pvc, err := framework.FindPVC(client, namespace, name)
-		if err != nil {
-			return err
-		}
-		pvc = update(pvc)
-
-		_, err = client.CoreV1().PersistentVolumeClaims(namespace).Update(context.TODO(), pvc, metav1.UpdateOptions{})
-		return err
-	}
-}
-func updateDataVolume(kvClient kubecli.KubevirtClient, namespace string, name string,
-	update func(dataVolume *cdiv1.DataVolume) *cdiv1.DataVolume) func() error {
-	return func() error {
-		dv, err := framework.FindDataVolume(kvClient, namespace, name)
-		if err != nil {
-			return err
-		}
-		dv = update(dv)
-
-		_, err = kvClient.CdiClient().CdiV1beta1().DataVolumes(namespace).Update(context.TODO(), dv, metav1.UpdateOptions{})
-		return err
-	}
-}
-
-func retryOnceOnErr(f func() error) Assertion {
-	err := f()
-	if err != nil {
-		err = f()
-	}
-
-	return Expect(err)
 }
 
 func runPodAndWaitSucceeded(kvClient kubecli.KubevirtClient, namespace string, podSpec *v1.Pod) *v1.Pod {

--- a/tests/vm_backup_test.go
+++ b/tests/vm_backup_test.go
@@ -20,6 +20,7 @@ import (
 	kubecli "kubevirt.io/client-go/kubecli"
 	"kubevirt.io/kubevirt-velero-plugin/tests/framework"
 	. "kubevirt.io/kubevirt-velero-plugin/tests/framework/matcher"
+	"kubevirt.io/kubevirt-velero-plugin/tests/patch"
 )
 
 const (
@@ -378,11 +379,12 @@ var _ = Describe("[smoke] VM Backup", func() {
 		if originalMAC == "" {
 			// This means there is no KubeMacPool running. We can simply choose a random address
 			originalMAC = "DE-AD-00-00-BE-AF"
-			update := func(vm *kvv1.VirtualMachine) *kvv1.VirtualMachine {
-				vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].MacAddress = originalMAC
-				return vm
-			}
-			retryOnceOnErr(updateVm(f.KvClient, f.Namespace.Name, vm.Name, update)).Should(BeNil())
+			patchData, err := patch.New(
+				patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", originalMAC),
+			).GeneratePayload()
+			Expect(err).ToNot(HaveOccurred())
+			_, err = f.KvClient.VirtualMachine(f.Namespace.Name).Patch(context.TODO(), vm.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusRunning)
 			Expect(err).ToNot(HaveOccurred())
@@ -455,18 +457,30 @@ var _ = Describe("[smoke] VM Backup", func() {
 			updateInstancetypeFunc := func() {
 				instancetype, err := f.KvClient.VirtualMachineInstancetype(f.Namespace.Name).Get(context.Background(), instancetypeName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				instancetype.Spec.CPU.Guest = instancetype.Spec.CPU.Guest + 1
-				instancetype.Spec.Memory.Guest.Add(resource.MustParse("128Mi"))
-				_, err = f.KvClient.VirtualMachineInstancetype(f.Namespace.Name).Update(context.Background(), instancetype, metav1.UpdateOptions{})
+				newCPU := instancetype.Spec.CPU.Guest + 1
+				newMemory := instancetype.Spec.Memory.Guest.DeepCopy()
+				newMemory.Add(resource.MustParse("128Mi"))
+				patchData, err := patch.New(
+					patch.WithReplace("/spec/cpu/guest", newCPU),
+					patch.WithReplace("/spec/memory/guest", newMemory.String()),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = f.KvClient.VirtualMachineInstancetype(f.Namespace.Name).Patch(context.Background(), instancetype.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
 
 			updateClusterInstancetypeFunc := func() {
 				instancetype, err := f.KvClient.VirtualMachineClusterInstancetype().Get(context.Background(), instancetypeName, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				instancetype.Spec.CPU.Guest = instancetype.Spec.CPU.Guest + 1
-				instancetype.Spec.Memory.Guest.Add(resource.MustParse("128Mi"))
-				_, err = f.KvClient.VirtualMachineClusterInstancetype().Update(context.Background(), instancetype, metav1.UpdateOptions{})
+				newCPU := instancetype.Spec.CPU.Guest + 1
+				newMemory := instancetype.Spec.Memory.Guest.DeepCopy()
+				newMemory.Add(resource.MustParse("128Mi"))
+				patchData, err := patch.New(
+					patch.WithReplace("/spec/cpu/guest", newCPU),
+					patch.WithReplace("/spec/memory/guest", newMemory.String()),
+				).GeneratePayload()
+				Expect(err).ToNot(HaveOccurred())
+				_, err = f.KvClient.VirtualMachineClusterInstancetype().Patch(context.Background(), instancetype.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
 				Expect(err).ToNot(HaveOccurred())
 			}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Some tests have been failing due to update conflicts. Using Patch() instead of Update() avoids these races and follows the pattern already adopted in other kubevirt repositories.

This PR:
- Adds a helper for building JSON patches.
- Refactors affected tests to use Patch() instead of Update().

**Special notes for your reviewer**:

Assisted-By: Claude <noreply@anthropic.com>

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

