### PR TITLE
Allow VM machine type to be set dynamically

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	ginkgo "github.com/onsi/ginkgo/v2"
@@ -38,6 +39,7 @@ const (
 	backupNamespaceEnv                     = "KVP_BACKUP_NS"
 	regionEnv                              = "KVP_REGION"
 	storageClassEnv                        = "KVP_STORAGE_CLASS"
+	defaultMachineTypeEnv                  = "KVP_DEFAULT_MACHINE_TYPE"
 
 	defaultRegionName      = "minio"
 	defaultBackupNamespace = "velero"
@@ -49,6 +51,7 @@ var (
 	ClientsInstance      = &Clients{}
 	BackupScriptInstance = &BackupScript{}
 	reporter             = NewKubernetesReporter()
+	DefaultMachineType   = "q35"
 )
 
 // Framework supports common operations used by functional/e2e tests. It holds the k8s and cdi clients,
@@ -745,4 +748,59 @@ func GetKubevirt(kvClient kubecli.KubevirtClient) *kv1.KubeVirt {
 
 	gomega.Expect(kvList.Items).To(gomega.HaveLen(1))
 	return &kvList.Items[0]
+}
+
+// InitDefaultMachineType sets DefaultMachineType from KVP_DEFAULT_MACHINE_TYPE or from worker node
+// architecture (first schedulable node with arch, else any node; see also Status.NodeInfo and label kubernetes.io/arch).
+func InitDefaultMachineType(client kubernetes.Interface) {
+	if v := strings.TrimSpace(os.Getenv(defaultMachineTypeEnv)); v != "" {
+		DefaultMachineType = v
+		fmt.Fprintf(ginkgo.GinkgoWriter, "DefaultMachineType (from %s env): %s\n", defaultMachineTypeEnv, DefaultMachineType)
+		return
+	}
+	arch, err := detectClusterArchitecture(client)
+	if err != nil {
+		fmt.Fprintf(ginkgo.GinkgoWriter, "WARNING: failed to detect cluster architecture, defaulting to %s: %v\n", DefaultMachineType, err)
+		return
+	}
+	switch arch {
+	case "s390x":
+		DefaultMachineType = "s390-ccw-virtio"
+	case "arm64":
+		DefaultMachineType = "virt"
+	default:
+		DefaultMachineType = "q35"
+	}
+	fmt.Fprintf(ginkgo.GinkgoWriter, "DefaultMachineType (detected arch %s): %s\n", arch, DefaultMachineType)
+}
+
+func detectClusterArchitecture(client kubernetes.Interface) (string, error) {
+	nl, err := client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{Limit: 500})
+	if err != nil {
+		return "", err
+	}
+	if len(nl.Items) == 0 {
+		return "", fmt.Errorf("no nodes in cluster")
+	}
+	var fallback string
+	for i := range nl.Items {
+		n := &nl.Items[i]
+		arch := strings.TrimSpace(n.Status.NodeInfo.Architecture)
+		if arch == "" {
+			arch = strings.TrimSpace(n.Labels[v1.LabelArchStable])
+		}
+		if arch == "" {
+			continue
+		}
+		if !n.Spec.Unschedulable {
+			return arch, nil
+		}
+		if fallback == "" {
+			fallback = arch
+		}
+	}
+	if fallback != "" {
+		return fallback, nil
+	}
+	return "", fmt.Errorf("no node reports architecture")
 }

--- a/tests/framework/kubectl.go
+++ b/tests/framework/kubectl.go
@@ -33,14 +33,15 @@ func (f *Framework) CreateKubectlCommand(args ...string) *exec.Cmd {
 	return cmd
 }
 
-// RunKubectlCreateYamlCommand replaces storageclassname placeholder with configured tests storageClass
-// in a given yaml, creates it and returns err
+// RunKubectlCreateYamlCommand substitutes {{KVP_STORAGE_CLASS}} and spec.domain.machine.type (template uses q35), then kubectl create.
 func (f *Framework) RunKubectlCreateYamlCommand(yamlPath string) error {
 	kubeconfig := f.KubeConfig
 	path := f.KubectlPath
 	storageClass := f.StorageClass
-
-	cmdString := fmt.Sprintf("cat %s | sed 's/{{KVP_STORAGE_CLASS}}/%s/g' | %s create -n %s -f -", yamlPath, storageClass, path, f.Namespace.Name)
+	cmdString := fmt.Sprintf(
+		"cat %s | sed 's|{{KVP_STORAGE_CLASS}}|%s|g' | sed 's|type: q35|type: %s|g' | %s create -n %s -f -",
+		yamlPath, storageClass, DefaultMachineType, path, f.Namespace.Name,
+	)
 	cmd := exec.Command("bash", "-c", cmdString)
 	kubeconfEnv := fmt.Sprintf("KUBECONFIG=%s", kubeconfig)
 	cmd.Env = append(os.Environ(), kubeconfEnv)

--- a/tests/framework/manifests_utils.go
+++ b/tests/framework/manifests_utils.go
@@ -76,8 +76,7 @@ func (f *Framework) CreateVMWithDVAndDVTemplate() error {
 }
 
 func (f *Framework) CreateVMWithPVC() error {
-	err := f.RunKubectlCommand("create", "-f", "manifests/vm_with_pvc.yaml", "-n", f.Namespace.Name)
-	return err
+	return f.RunKubectlCreateYamlCommand("manifests/vm_with_pvc.yaml")
 }
 
 func (f *Framework) CreateVMForHotplug() error {
@@ -86,6 +85,5 @@ func (f *Framework) CreateVMForHotplug() error {
 }
 
 func (f *Framework) CreateVMIWithDataVolume() error {
-	err := f.RunKubectlCommand("create", "-f", "manifests/vmi_with_dv.yaml", "-n", f.Namespace.Name)
-	return err
+	return f.RunKubectlCreateYamlCommand("manifests/vmi_with_dv.yaml")
 }

--- a/tests/framework/vm.go
+++ b/tests/framework/vm.go
@@ -127,7 +127,7 @@ version: 2`
 				},
 			},
 			Machine: &v1.Machine{
-				Type: "q35",
+				Type: DefaultMachineType,
 			},
 			Devices: v1.Devices{
 				Rng: &v1.Rng{},

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -68,6 +68,7 @@ func BuildTestSuite() {
 		}
 		framework.ClientsInstance.K8sClient = k8sClient
 
+		framework.InitDefaultMachineType(k8sClient)
 		listPlugins()
 	})
 

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -14,6 +14,7 @@ import (
 	kvv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"kubevirt.io/kubevirt-velero-plugin/tests/framework"
 )
 
 const (
@@ -60,7 +61,7 @@ var newVMSpecBlankDVTemplate = func(vmName, size string) *kvv1.VirtualMachine {
 							},
 						},
 						Machine: &kvv1.Machine{
-							Type: "",
+							Type: framework.DefaultMachineType,
 						},
 						Devices: kvv1.Devices{
 							Disks: []kvv1.Disk{
@@ -132,7 +133,7 @@ var newVMSpec = func(vmName, size string, volumeSource kvv1.VolumeSource) *kvv1.
 							},
 						},
 						Machine: &kvv1.Machine{
-							Type: "",
+							Type: framework.DefaultMachineType,
 						},
 						Devices: kvv1.Devices{
 							Disks: []kvv1.Disk{
@@ -191,7 +192,7 @@ func newVMISpec(vmiName string) *kvv1.VirtualMachineInstance {
 					},
 				},
 				Machine: &kvv1.Machine{
-					Type: "q35",
+					Type: framework.DefaultMachineType,
 				},
 				Devices: kvv1.Devices{
 					Rng:   &kvv1.Rng{},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds multi-architecture support for VM machine type in the test framework. Previously, the machine type was hardcoded to `q35`, which is x86_64-specific. This caused all VM and VMI creation to be rejected by the KubeVirt admission webhook on s390x with:

```
spec.template.spec.domain.machine.type is not supported: q35 (allowed values: [s390-ccw-virtio*])
```

This PR:
- Introduces `InitDefaultMachineType()` which auto-detects the cluster architecture from node info and sets the appropriate machine type (`s390-ccw-virtio` for s390x, `virt` for arm64, `q35` for amd64)
- Supports an env var override (`KVP_DEFAULT_MACHINE_TYPE`) for manual control
- Replaces all hardcoded `q35` references in Go test specs with the detected default
- Updates `RunKubectlCreateYamlCommand` to substitute `type: q35` in YAML manifests at apply time
- Routes `CreateVMWithPVC` and `CreateVMIWithDataVolume` through the YAML substitution pipeline (they previously bypassed it via raw `RunKubectlCommand`)

Validated on an s390x OpenShift cluster: machine type correctly detected as `s390-ccw-virtio`, VMs created and reached Running state without admission webhook rejections.

**Which issue(s) this PR fixes**:
Fixes test failures on s390x clusters where all VM-based tests fail due to hardcoded `q35` machine type.

**Special notes for your reviewer**:

- The 8 YAML manifests under `tests/manifests/` still contain `type: q35` as a placeholder. This is intentional -- `RunKubectlCreateYamlCommand` rewrites it at apply time via `sed`. Changing the YAML files themselves was avoided to keep the diff minimal and because the sed-based substitution was already the established pattern for `{{KVP_STORAGE_CLASS}}`.
- The `manifests_utils.go` changes for `CreateVMWithPVC` and `CreateVMIWithDataVolume` are necessary because they were the only two VM/VMI-creating functions using raw `RunKubectlCommand` instead of `RunKubectlCreateYamlCommand`, meaning neither storage class nor machine type substitution was happening for them.

**Release note**:
```release-note
NONE
```