### PR TITLE
README: Update compatibility table and document tested backup methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,20 +45,32 @@ An action that handles the virt-launcher `Pod`. It makes sure virt-launcher pod 
 
 ## Compatibility
 
-Plugin versions and respective Velero/Kubevirt/CDI versions that are tested to be compatible.
+Plugin versions and respective Velero, KubeVirt, and CDI versions that are tested to be compatible.
 
-| Plugin Version  | Velero Version | Kubevirt Version | CDI Version  |
-|-----------------|----------------|------------------|--------------|
-| v0.2.0          | v1.6.x, v1.7.x | v0.48.x          | \>= v1.37.0  |(NOT RECOMMENDED TO USE)
-| v0.6.x          | v1.12.x        | \>= v1.0.0       | \>= v1.57.0  |
+| Plugin Version      | Velero Version | KubeVirt Version | CDI Version  |
+|---------------------|----------------|------------------|--------------|
+| v0.9.x              | v1.18.x        | >= v1.1.0        | >= v1.57.0   |
+| v0.8.x              | v1.16.x        | >= v1.1.0        | >= v1.57.0   |
+| v0.7.x              | v1.14.x        | >= v1.1.0        | >= v1.57.0   |
+| v0.6.x              | v1.12.x        | >= v1.0.0        | >= v1.57.0   |
+
+### Backup Methods
+
+This plugin has been tested with the following Velero backup methods:
+
+- **CSI volume snapshots** — using the [Velero CSI plugin](https://velero.io/docs/main/csi/)
+- **CSI volume snapshots with DataMover** — for moving snapshots to remote storage using [CSI Snapshot Data Movement](https://velero.io/docs/main/csi-snapshot-data-movement/)
+
+Other backup methods, such as file system backup (Kopia/Restic) or native cloud provider snapshots,
+have **not been tested** with this plugin and may not work correctly with KubeVirt volumes.
 
 ## Install
 
 To install the plugin check current velero documentation https://velero.io/docs/main/overview-plugins/.
-Below example for kubevirt-velero-plugin version v0.2.0 on Velero 1.7.0
+Below example for kubevirt-velero-plugin version v0.9.0 on Velero 1.18.0
 
 ```bash
-velero plugin add quay.io/kubevirt/kubevirt-velero-plugin:v0.2.0
+velero plugin add quay.io/kubevirt/kubevirt-velero-plugin:v0.9.0
 ```
 
 ## Backup/Restore Virtual Machines Using the Plugin


### PR DESCRIPTION
### Update README compatibility table and document tested backup methods

**What this PR does / why we need it**:

Updates the README compatibility table to cover all releases from v0.6.x through latest. The previous table only had 2 rows (v0.2.0 and v0.6.x) and was outdated. Versions were verified
  against go.mod and hack/config.sh at each tag. Also adds a backup methods section clarifying that CSI snapshots and CSI with DataMover are the tested approaches, and updates the install  
  example to v0.9.0.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

KubeVirt and CDI versions reflect actual API minimums based on source code analysis, not just what go.mod pins. For example, v0.8.x lists KubeVirt >= v1.1.0 (when Status.InstancetypeRef was introduced) rather than v1.5.0 (what go.mod/hack/config.sh happen to use). 

**Release note**:

<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

## Details:

Rework the compatibility section in README.md:

- Replace the outdated 2-row table with a complete 4-column table
  covering v0.6.x through latest (unreleased)
- KubeVirt and CDI versions reflect actual API minimums based on
  code analysis, not just what go.mod or hack/config.sh happen to pin
- Drop v0.2.0–v0.5.0 entries (see "Removed versions" below)
- Add a "Backup Methods" subsection listing tested backup approaches
- Update the install example from v0.2.0 to v0.9.0

#### How versions were determined

**Velero**: taken from `hack/config.sh` (`VELERO_VERSION`) — the plugin
framework is a hard dependency and the version must match.

**KubeVirt**: determined by which API fields the code actually uses. The
go.mod and hack/config.sh versions are often higher than strictly required,
so the minimum was derived from the API features in the source code.

**CDI**: the plugin uses `DataVolume.Status.Phase`, the `cdiv1.Succeeded`
constant, and annotation get/set — all part of the stable v1beta1 API. These
have not changed across CDI releases. The minimum v1.57.0 is the lowest
`containerized-data-importer-api` module version present in any listed
release's go.mod (v0.6.0).

#### Version references

##### v0.9.x — Velero v1.18.x, KubeVirt >= v1.1.0, CDI >= v1.57.0

Branch: [`main`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/main)

- `go.mod`: Velero v1.18.0, KubeVirt v1.7.1, CDI API v1.64.0
- `hack/config.sh`: `VELERO_VERSION=v1.18.0`, `KUBEVIRT_VERSION=v1.7.1`
- Velero bumped in [`66e601d9`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/66e601d9)
  *"update to latest velero versions, use csi, wait for snapshots and more :) (#404)"*
- KubeVirt bumped through [`c15a79cb`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/c15a79cb)
  (v1.6.0) and [`66e601d9`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/66e601d9) (v1.7.1)
- Adds VolumeSnapshot backup/restore actions via [`595cf415`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/595cf415)
  *"feat: Add PVC and VS labeling with user data preservation (#396)"*
- KubeVirt minimum remains v1.1.0 — no new KubeVirt API fields were added
  beyond what v0.8.x already uses (`vm.Status.InstancetypeRef`, cluster-scoped
  instancetype/preference types)

##### v0.8.x — Velero v1.16.x, KubeVirt >= v1.1.0, CDI >= v1.57.0

Tag: [`v0.8.0`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/v0.8.0)

- `go.mod`: Velero v1.16.0, KubeVirt v1.5.0, CDI API v1.62.0
- `hack/config.sh`: `VELERO_VERSION=v1.16.0`, `KUBEVIRT_VERSION=v1.5.0`
- Velero bumped in [`1a6b3b5f`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/1a6b3b5f)
  *"Bump github.com/vmware-tanzu/velero from 1.14.0 to 1.16.0 (#355)"*
- Uses `vm.Status.InstancetypeRef` / `vm.Status.PreferenceRef`, added in
  [`8548e70d`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/8548e70d)
  *"Use vm.Status.{Instancetype,Preference}Ref to backup and restore instance type related ControllerRevisions (#333)"*
  — these status fields were introduced in KubeVirt v1.1.0, hence the minimum
- Tested with KubeVirt v1.5.0 but the API surface does not require anything
  beyond v1.1.0

##### v0.7.x — Velero v1.14.x, KubeVirt >= v1.1.0, CDI >= v1.57.0

Tags: [`v0.7.0`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/v0.7.0),
[`v0.7.1`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/v0.7.1)

- `go.mod`: Velero v1.14.0, KubeVirt v1.2.0, CDI API v1.58.0
- `hack/config.sh`: v0.7.0 at `KUBEVIRT_VERSION=v1.1.1`, v0.7.1 at `KUBEVIRT_VERSION=v1.3.0`
- Velero bumped in [`568b5c00`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/568b5c00)
  *"Bump velero library and deployment to 1.14 + go update and kubevirtci (#249)"*
- KubeVirt minimum is v1.1.0 because:
  - [`d300cd13`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/d300cd13) bumped
    kubevirt.io/api from 1.0.0 to 1.1.1
  - [`a8423daf`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/a8423daf) added
    VirtualMachineClusterInstancetype/Preference support (backported to v0.7.1),
    which requires KubeVirt v1.1.0+ APIs

##### v0.6.x — Velero v1.12.x, KubeVirt >= v1.0.0, CDI >= v1.57.0

Tags: [`v0.6.0`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/v0.6.0),
[`v0.6.1`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/v0.6.1),
[`v0.6.2`](https://github.com/kubevirt/kubevirt-velero-plugin/tree/v0.6.2)

- `go.mod`: Velero v1.11.1, KubeVirt v1.0.0, CDI API v1.57.0
- v0.6.0 and v0.6.2 tested with Velero v1.12.0 / v1.12.3 respectively
- v0.6.1 temporarily tested with Velero v1.9.4 ([`22c61d9d`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/22c61d9d)),
  corrected back to v1.12.x in v0.6.2 ([`dba1cf1f`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/dba1cf1f))
- KubeVirt v1.0.0 introduced in [`bacfcd57`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/bacfcd57)
  *"Update kubevirtci to latest and KubeVirt to 1.0, fix all the tests (#187)"*
- KubeVirt minimum is v1.0.0 — code uses `Spec.Instancetype`, `Spec.Preference`,
  and `Spec.AccessCredentials`, all part of the stable v1.0.0 API. Does not use
  `Status.InstancetypeRef` or cluster-scoped types (those came in v0.7.x/v0.8.x).

#### Removed versions

**v0.4.0 and v0.5.0** had mismatched `go.mod` and `hack/config.sh` Velero versions:

| Plugin | go.mod Velero | hack/config.sh Velero |
|--------|---------------|-----------------------|
| v0.5.0 | v1.10.0       | v1.8.1                |
| v0.4.0 | v1.7.0        | v1.8.1                |

Both also target pre-1.0 KubeVirt (v0.57.0 / v0.58.0).

**v0.2.0 and v0.3.x** target KubeVirt v0.43.0 and Velero v1.5.3–v1.7.0.
Already marked as not recommended in the previous README.

#### Backup methods

Added a subsection documenting tested backup methods. The functional tests
and deployment scripts ([`hack/velero/deploy-velero.sh`](https://github.com/kubevirt/kubevirt-velero-plugin/blob/v0.8.0/hack/velero/deploy-velero.sh))
cover the following:

- **CSI volume snapshots** — covered by functional tests; CSI snapshot handling
  added in [`66e601d9`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/66e601d9),
  VolumeSnapshot actions added in [`595cf415`](https://github.com/kubevirt/kubevirt-velero-plugin/commit/595cf415)
- **CSI with DataMover** — for moving snapshots to remote object storage

File system backup (Kopia/Restic) and native cloud provider snapshots are not
covered by any existing tests and are not community supported methods for the velero kubevirt plugin.