### PR TITLE
Integrate native KubeVirt backup API (backup.kubevirt.io/v1alpha1)

### DIFF
--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,59 @@
+# RBAC for kubevirt-velero-plugin native backup integration.
+# Grants the Velero service account permissions to create/manage
+# VirtualMachineBackup and VirtualMachineBackupTracker CRs,
+# as well as scratch PVCs for the backup data.
+#
+# Apply this in addition to the standard Velero RBAC when using
+# the native KubeVirt backup feature (backup.kubevirt.io/v1alpha1).
+#
+# Usage:
+#   kubectl apply -f deploy/rbac.yaml
+#
+# The standard Velero RBAC already covers kubevirt.io resources.
+# This file adds only the backup.kubevirt.io permissions.
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubevirt-velero-plugin-native-backup
+  labels:
+    app.kubernetes.io/name: kubevirt-velero-plugin
+    app.kubernetes.io/component: native-backup
+rules:
+  # Native backup CRDs
+  - apiGroups: ["backup.kubevirt.io"]
+    resources: ["virtualmachinebackups", "virtualmachinebackuptrackers"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  # Scratch PVC management
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "create", "delete", "deletecollection"]
+  # Feature detection via CRD discovery
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+  # Guest agent detection (VMI status)
+  - apiGroups: ["kubevirt.io"]
+    resources: ["virtualmachineinstances"]
+    verbs: ["get"]
+  # Plugin configuration
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get"]
+    resourceNames: ["kubevirt-velero-plugin-config"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubevirt-velero-plugin-native-backup
+  labels:
+    app.kubernetes.io/name: kubevirt-velero-plugin
+    app.kubernetes.io/component: native-backup
+subjects:
+  - kind: ServiceAccount
+    name: velero
+    namespace: velero
+roleRef:
+  kind: ClusterRole
+  name: kubevirt-velero-plugin-native-backup
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/design/native-backup-integration.md
+++ b/docs/design/native-backup-integration.md
@@ -1,0 +1,250 @@
+# Native KubeVirt Backup API Integration (PR #412)
+
+Status: Draft
+Author: @aagarwal-apexanalytix
+Tracking issue: [#411](https://github.com/kubevirt/kubevirt-velero-plugin/issues/411)
+PR: [#412](https://github.com/kubevirt/kubevirt-velero-plugin/pull/412)
+
+## Summary
+
+Add optional, opt-in support for the native KubeVirt backup API
+(`backup.kubevirt.io/v1alpha1`) inside the existing `kubevirt-velero-plugin`,
+without introducing a new controller or Velero core changes. Native
+`VirtualMachineBackup` is used to produce a CBT/quiesced copy of VM volumes
+into a scratch PVC; Velero then backs up the scratch PVC using whatever
+snapshot path is already configured (CSI, fs-backup, datamover). The existing
+CSI path remains the default and is used as a fallback whenever the native
+path is unavailable.
+
+**Scope caveat: backup only, no end-to-end restore.** This PR ships the
+backup side. The scratch PVC contains qcow2 files (full + incrementals);
+restore puts those files back on a PVC via the existing CSI restore path,
+but reconstituting a usable VM disk from the qcow2 chain (`qemu-img
+rebase` / `convert`) is intentionally left to the OADP kubevirt-datamover.
+Users who need end-to-end native restore today should use the OADP
+datamover; users who want CBT/quiesced *backups* today with upstream
+Velero can use this.
+
+This document compares the proposal to the [OADP kubevirt-datamover
+design](https://github.com/openshift/oadp-operator/blob/oadp-dev/docs/design/kubevirt-datamover.md)
+and the related
+[migtools/kubevirt-datamover-controller](https://github.com/migtools/kubevirt-datamover-controller),
+and explains why we believe these two approaches are complementary rather
+than competing.
+
+## Background
+
+KubeVirt `v1.8` exposes a native backup API: `VirtualMachineBackup` and
+`VirtualMachineBackupTracker` (`backup.kubevirt.io/v1alpha1`), built on top
+of QEMU dirty bitmaps / CBT. It enables:
+
+- Quiesced, crash-consistent snapshots when the QEMU guest agent is present
+- True block-level incremental backup (only changed blocks)
+- VM awareness at the hypervisor level rather than the storage/PVC level
+
+Today, `kubevirt-velero-plugin` only integrates with Velero via CSI
+`VolumeSnapshot`s. For VMs this means Velero sees PVCs, snapshots them,
+and (optionally) moves data via kopia. The hypervisor is uninvolved, so
+incremental backups are computed by scanning whole volumes rather than
+reading the CBT.
+
+The OADP proposal solves this by introducing a new data-mover path: a
+custom `DataUpload.Spec.DataMover=kubevirt`, a new
+`kubevirt-datamover-controller` that reconciles those DataUploads, and a
+custom object-storage layout for qcow2 checkpoints. That design is the
+"full" native-backup story and requires changes to OADP, a new controller,
+and small changes to Velero.
+
+This PR takes a much smaller step that is useful today without any of
+those moving parts.
+
+## Goals
+
+- Let users opt into CBT/quiesced backup of VMs using only the existing
+  `kubevirt-velero-plugin` binary.
+- Work with any upstream Velero release (no Velero core changes).
+- Work with any Velero backup backend (CSI snapshot, fs-backup, CSI
+  datamover, any third-party datamover) — the plugin does not reinvent
+  object-storage layout or kopia plumbing.
+- Preserve existing behavior exactly when the feature is not enabled.
+- Degrade gracefully: if CRDs are missing, the VM is offline, the agent is
+  absent, or any native call fails, fall back to the existing CSI path.
+
+## Non-goals
+
+- Replacing or duplicating the OADP kubevirt-datamover.
+- Defining a new on-disk layout for qcow2 / CBT data in the BSL.
+- Adding a new controller or CRDs owned by this plugin.
+- Implementing restore from the CBT chain. For restore, Velero restores
+  the scratch PVC contents exactly as it already does for any other PVC;
+  reconstituting an incremental chain is out of scope for this change and
+  remains the OADP datamover's territory.
+
+## High-level design
+
+### Opt-in surface
+
+All behavior is off by default. Users enable it per-backup with labels on
+the Velero `Backup` object, or cluster-wide via a ConfigMap
+(`kubevirt-velero-plugin-config` in `velero`). Labels always win over
+ConfigMap values.
+
+| Label | Purpose |
+|-------|---------|
+| `velero.kubevirt.io/native-backup` | Enable native backup for this Backup |
+| `velero.kubevirt.io/incremental-backup` | Enable incremental via tracker |
+| `velero.kubevirt.io/skip-quiesce` | Force skip filesystem quiesce |
+| `velero.kubevirt.io/scratch-storage-class` | Override scratch PVC storage class |
+| `velero.kubevirt.io/force-full-every-n` | Force full backup every N incrementals |
+| `velero.kubevirt.io/native-backup-concurrency` | Max concurrent native backups |
+
+If the label is absent, the plugin behaves exactly as it does today.
+
+### Flow (backup)
+
+```
+   Velero Backup                 Plugin (BIA v2)                KubeVirt
+   ─────────────                 ────────────────               ────────
+        │                                │                         │
+        │  Execute(VM)                   │                         │
+        ├───────────────────────────────►│                         │
+        │                                │ IsEnabled? CRDs?        │
+        │                                │ VM running? agent?      │
+        │                                │                         │
+        │                                │ create scratch PVC      │
+        │                                │ create VirtualMachine-  │
+        │                                │   Backup (+tracker)     │
+        │                                ├────────────────────────►│
+        │                                │                         │ QEMU quiesce
+        │                                │                         │ CBT → scratch PVC
+        │◄──── operationID, extras ──────┤                         │
+        │                                │                         │
+        │  Progress(opID)                │                         │
+        ├───────────────────────────────►│  poll VMB status        │
+        │                                ├────────────────────────►│
+        │◄──── progress% / done ─────────┤                         │
+        │                                │                         │
+        │ (Velero snapshots the scratch  │                         │
+        │  PVC like any other PVC — via  │                         │
+        │  its normal CSI/datamover      │                         │
+        │  path)                         │                         │
+        │                                │                         │
+        │  (on backup delete)            │                         │
+        ├───────────────────────────────►│ DeleteItemAction cleans │
+        │                                │ up VMB + scratch PVC    │
+```
+
+Key points:
+
+- The source PVCs are labelled `velero.kubevirt.io/native-backed=true`
+  so the existing PVC BIA (`pvc_backup_item_action.go`) skips them — no
+  double-snapshot on the source.
+- The scratch PVC is tagged with
+  `velero.kubevirt.io/scratch-for-backup=<vmb-name>` and a
+  `velero.kubevirt.io/scratch-pvc-ttl` annotation; Velero picks it up
+  through its normal PVC path.
+- `VirtualMachineBackupTracker` is used to carry checkpoint state for
+  incremental runs; `force-full-every-n` bounds the chain length.
+- If any native step fails (CRD missing, VM offline, VMB error, timeout),
+  the plugin deletes any scratch state it created and returns without
+  setting the "native-backed" label, so Velero's normal CSI path runs.
+- Annotations are applied to the VM's `unstructured` item (not a decoded
+  `VirtualMachine` struct), so they are persisted into the backup tarball.
+
+### Flow (restore)
+
+No new restore-side behavior. The scratch PVC is restored normally by
+Velero/CSI; the VMB/VMBT CRs are filtered out of the restore (they would
+otherwise trigger a new backup). Reconstructing a CBT chain into a usable
+VM disk is intentionally left to the OADP datamover path.
+
+### Components touched
+
+- New package `pkg/util/nativebackup/` (~1.2k LoC production + ~340 LoC
+  tests) — config, detection, scratch PVC, VMB/tracker lifecycle,
+  progress, agent check.
+- `vm_backup_item_action.go` upgraded to BIA v2 (`Execute` / `Progress` /
+  `Cancel`) so native backup can run asynchronously.
+- `vm_restore_item_action.go` upgraded to RIA v2 for symmetry.
+- New `vm_delete_item_action.go` to clean up VMB + scratch PVCs on backup
+  deletion.
+- New `vm_item_block_action.go` so VM + scratch PVC + related resources
+  are backed up atomically.
+- RBAC for `backup.kubevirt.io` resources.
+- Unit tests for the new package and the v2 actions.
+
+## Comparison to OADP kubevirt-datamover
+
+| Dimension | OADP kubevirt-datamover | This PR |
+|---|---|---|
+| Scope | Full data-mover replacement | Plugin-only feature |
+| New controller | Yes (`kubevirt-datamover-controller`) | No |
+| Velero core changes | Yes (volume policy, `SnapshotType`) | None |
+| Ships where | OADP / migtools fork | Upstream `kubevirt-velero-plugin` |
+| BSL layout | Custom qcow2 directory tree | Unchanged — uses whatever Velero already does |
+| Storage path | Direct object-store writes from datamover pod | Scratch PVC → Velero's existing CSI/datamover |
+| Incremental metadata | Per-VM `index.json` in BSL | `VirtualMachineBackupTracker` in cluster + annotations |
+| Restore | Custom datamover restore pod + `qemu-img rebase` | Standard CSI restore of scratch PVC |
+| Target user | OADP/OpenShift user wanting CBT end-to-end | Upstream KubeVirt + Velero user wanting CBT quiesce today |
+| Upgrade cost | New CRDs, new controller, new BSL content | Add label to an existing Backup |
+
+### Why both can coexist
+
+- The OADP design is the "right" long-term answer for CBT-native
+  end-to-end backup (including true incremental restore). It is also a
+  larger change, owned by OADP, and depends on Velero core work landing.
+- This PR is a short-lever improvement that any KubeVirt + Velero user
+  (not just OADP users) can turn on today. It uses the native API for the
+  parts where it matters most — quiesce, CBT, VM-aware snapshot — and
+  lets Velero's existing machinery do data movement.
+- Because this PR is strictly additive and defaults-off, it does not block
+  or contradict the OADP datamover landing later. A future user of the
+  OADP datamover would simply leave these labels unset, and this plugin
+  stays out of the way.
+- If maintainers prefer, the feature can later be retargeted to produce
+  `DataUpload`s with `Spec.DataMover=kubevirt` once the OADP/Velero side
+  lands, reusing the same `pkg/util/nativebackup/` primitives.
+
+### Why not just put this in the migtools fork
+
+- `migtools/kubevirt-velero-plugin` is currently ~14 commits ahead of
+  upstream, and the delta is almost entirely OpenShift CI carries and
+  rebase-bot merges — no native-backup implementation lives there.
+- `migtools/kubevirt-datamover-controller` implements the OADP design
+  above, which is a separate shape.
+- Upstream users who don't run OADP still benefit from CBT/quiesce. The
+  natural home for that is here.
+
+## Open questions for maintainers
+
+1. **Home of the feature.** Do you want the native-backup path to live
+   here long-term, or do you see this as a stopgap until the OADP
+   datamover lands? We are happy to scope the PR accordingly (e.g. mark
+   as experimental, hide behind a build tag, or plan a migration path).
+
+2. **Opt-in surface.** Labels on the Backup object are used today for
+   ergonomics and because volume-policy support for "unrecognized
+   actions" is not yet in Velero. Would you prefer a ConfigMap-only
+   surface, or something else (e.g. an annotation on the VM, a Velero
+   plugin config key)?
+
+3. **Relationship to OADP DataUpload.** Is there interest in having this
+   plugin optionally emit a `DataUpload` with `Spec.DataMover=kubevirt`
+   (instead of the scratch-PVC approach) once the OADP controller is
+   available? That would let the two efforts share one front-end.
+
+4. **PR shape.** The current PR is size/XXL. If the design is acceptable
+   in principle, we can split it into: (a) design doc, (b)
+   `pkg/util/nativebackup/` package, (c) v2 action upgrades + DIA/IBA,
+   (d) RBAC + config. Happy to do that.
+
+5. **Testing.** What's the expected bar for e2e coverage of a new path
+   like this? The current PR ships unit tests; we can add lane coverage
+   against a KubeVirt v1.8+ cluster if CI supports it.
+
+## Out of scope / future work
+
+- Restore of an incremental chain (handled by OADP datamover).
+- Pull-mode backup (KubeVirt enhancement, not yet stable).
+- A plugin-owned object-storage layout for qcow2 files.
+- A plugin-owned controller.

--- a/main.go
+++ b/main.go
@@ -31,16 +31,22 @@ import (
 func main() {
 	framework.NewServer().
 		BindFlags(pflag.CommandLine).
-		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-vm-action", newVMRestoreItemAction).
+		// Restore actions — VM upgraded to v2 for AreAdditionalItemsReady
+		RegisterRestoreItemActionV2("kubevirt-velero-plugin/restore-vm-action", newVMRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-vmi-action", newVMIRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pvc-action", newPVCRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pod-action", newPodRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-volumesnapshot-action", newVolumeSnapshotRestoreItemAction).
+		// Backup actions — VM upgraded to v2 for async native backup
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-datavolume-action", newDVBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-pvc-action", newPVCBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-volumesnapshot-action", newVolumeSnapshotBackupItemAction).
-		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachine-action", newVMBackupItemAction).
+		RegisterBackupItemActionV2("kubevirt-velero-plugin/backup-virtualmachine-action", newVMBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachineinstance-action", newVMIBackupItemAction).
+		// Delete action — cleanup native backup artifacts on backup deletion
+		RegisterDeleteItemAction("kubevirt-velero-plugin/delete-vm-action", newVMDeleteItemAction).
+		// Item block action — atomic backup of VM + related resources
+		RegisterItemBlockAction("kubevirt-velero-plugin/block-vm-action", newVMItemBlockAction).
 		Serve()
 }
 
@@ -60,7 +66,7 @@ func newDVBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
 }
 
 func newVMBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
-	logger.Debug("Creating VMBackupItemAction")
+	logger.Debug("Creating VMBackupItemAction (v2)")
 	return plugin.NewVMBackupItemAction(logger), nil
 }
 
@@ -75,7 +81,7 @@ func newVMIBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
 }
 
 func newVMRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
-	logger.Debug("Creating VMRestoreItemAction")
+	logger.Debug("Creating VMRestoreItemAction (v2)")
 	return plugin.NewVMRestoreItemAction(logger), nil
 }
 
@@ -99,3 +105,12 @@ func newVolumeSnapshotRestoreItemAction(logger logrus.FieldLogger) (interface{},
 	return plugin.NewVolumeSnapshotRestoreItemAction(logger), nil
 }
 
+func newVMDeleteItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating VMDeleteItemAction")
+	return plugin.NewVMDeleteItemAction(logger), nil
+}
+
+func newVMItemBlockAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating VMItemBlockAction")
+	return plugin.NewVMItemBlockAction(logger), nil
+}

--- a/pkg/plugin/pvc_backup_item_action.go
+++ b/pkg/plugin/pvc_backup_item_action.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util/nativebackup"
 
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
@@ -60,8 +61,14 @@ func (p *PVCBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Back
 		return nil, nil, err
 	}
 
-	// Add UID label for selective restore
+	// Skip PVCs that are being handled by native backup (prevents CSI double-snapshot)
 	labels := metadata.GetLabels()
+	if labels != nil && labels[nativebackup.NativeBackedPVCLabel] == "true" {
+		p.log.Infof("PVC %s/%s handled by native backup, skipping UID labeling", metadata.GetNamespace(), metadata.GetName())
+		return item, []velero.ResourceIdentifier{}, nil
+	}
+
+	// Add UID label for selective restore
 	if labels == nil {
 		labels = make(map[string]string)
 	}

--- a/pkg/plugin/vm_backup_item_action.go
+++ b/pkg/plugin/vm_backup_item_action.go
@@ -22,6 +22,7 @@ package plugin
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -29,15 +30,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
 	kvcore "kubevirt.io/api/core/v1"
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util/kvgraph"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util/nativebackup"
 )
 
-// VMBackupItemAction is a backup item action for backing up DataVolumes
+// VMBackupItemAction is a v2 backup item action for backing up VirtualMachines.
+// It supports both the traditional CSI snapshot path and the native KubeVirt backup API
+// (backup.kubevirt.io/v1alpha1) for CBT/incremental backup when available and enabled.
 type VMBackupItemAction struct {
 	log logrus.FieldLogger
 }
@@ -47,43 +52,48 @@ func NewVMBackupItemAction(log logrus.FieldLogger) *VMBackupItemAction {
 	return &VMBackupItemAction{log: log}
 }
 
-// AppliesTo returns information about which resources this action should be invoked for.
-// The IncludedResources and ExcludedResources slices can include both resources
-// and resources with group names. These work: "ingresses", "ingresses.extensions".
-// A VMBackupItemAction's Execute function will only be invoked on items that match the returned
-// selector. A zero-valued ResourceSelector matches all resources.
-func (p *VMBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
-	return velero.ResourceSelector{
-			IncludedResources: []string{
-				"VirtualMachine",
-			},
-		},
-		nil
+// Name returns the name of this BIA (required by v2 interface).
+func (p *VMBackupItemAction) Name() string {
+	return "kubevirt-velero-plugin/backup-virtualmachine-action"
 }
 
-// Execute returns VM's DataVolumes as extra items to back up.
-func (p *VMBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, error) {
-	p.log.Info("Executing VMBackupItemAction")
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *VMBackupItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{
+			"VirtualMachine",
+		},
+	}, nil
+}
+
+// Execute backs up a VirtualMachine, optionally using the native KubeVirt backup API.
+// Returns:
+//   - item: the (possibly mutated) VM
+//   - additionalItems: resources to back up immediately
+//   - operationID: non-empty if an async native backup was initiated
+//   - postOperationItems: resources to back up after the async operation completes (scratch PVCs)
+//   - error
+func (p *VMBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backup) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+	p.log.Info("Executing VMBackupItemAction (v2)")
 
 	if backup == nil {
-		return nil, nil, fmt.Errorf("backup object nil!")
+		return nil, nil, "", nil, fmt.Errorf("backup object nil!")
 	}
 
 	vm := new(kvcore.VirtualMachine)
 	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.UnstructuredContent(), vm); err != nil {
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, "", nil, errors.WithStack(err)
 	}
 
 	safe, err := p.canBeSafelyBackedUp(vm, backup)
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, "", nil, errors.WithStack(err)
 	}
 	if !safe {
-		return nil, nil, fmt.Errorf("VM cannot be safely backed up")
+		return nil, nil, "", nil, fmt.Errorf("VM cannot be safely backed up")
 	}
 
-	// we can skip all checks that ensure consistency
-	// if we just want to backup for metadata purposes
+	// Consistency checks (skip for metadata-only backups)
 	if !util.IsMetadataBackup(backup) {
 		skipVolume := func(volume kvcore.Volume) bool {
 			return volumeInDVTemplates(volume, vm)
@@ -91,47 +101,214 @@ func (p *VMBackupItemAction) Execute(item runtime.Unstructured, backup *v1.Backu
 
 		restore, err := util.RestorePossible(vm.Spec.Template.Spec.Volumes, backup, vm.Namespace, skipVolume, p.log)
 		if err != nil {
-			return nil, nil, errors.WithStack(err)
+			return nil, nil, "", nil, errors.WithStack(err)
 		}
 		if !restore {
-			return nil, nil, fmt.Errorf("VM would not be restored correctly")
+			return nil, nil, "", nil, fmt.Errorf("VM would not be restored correctly")
 		}
 	}
 
+	// Compute dependency graph (unchanged from v1)
 	extra, err := kvgraph.NewVirtualMachineBackupGraph(vm)
 	if err != nil {
-		return nil, nil, errors.WithStack(err)
+		return nil, nil, "", nil, errors.WithStack(err)
 	}
 
-	// By default velero will remove the status field of an object before restore:
-	//
-	// https://velero.io/docs/main/restore-reference/#restore-status-field-of-objects
-	//
-	// To workaround this we need to copy references to instance type and
-	// preference controller revisions from the status of the original
-	// VirtualMachine into the core spec of the backed up VirtualMachine. These
-	// values are then repopulated into the status of the restored VirtualMachine
-	// by the VM controller allowing future velero backups to work as expected.
+	// Preserve instancetype/preference controller revisions (unchanged from v1)
 	if vm.Spec.Instancetype != nil && vm.Status.InstancetypeRef != nil && vm.Status.InstancetypeRef.ControllerRevisionRef != nil {
 		vm.Spec.Instancetype.RevisionName = vm.Status.InstancetypeRef.ControllerRevisionRef.Name
 	}
-
 	if vm.Spec.Preference != nil && vm.Status.PreferenceRef != nil && vm.Status.PreferenceRef.ControllerRevisionRef != nil {
 		vm.Spec.Preference.RevisionName = vm.Status.PreferenceRef.ControllerRevisionRef.Name
 	}
 
-	vmMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
-	if err != nil {
-		return nil, nil, errors.WithStack(err)
+	// Decide whether to use native backup
+	if p.shouldUseNativeBackup(vm, backup) {
+		return p.executeNativeBackup(vm, backup, item, extra)
 	}
 
-	return &unstructured.Unstructured{Object: vmMap}, extra, nil
+	// CSI path: sync return (no operationID, no postItems)
+	vmMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
+	if err != nil {
+		return nil, nil, "", nil, errors.WithStack(err)
+	}
+	return &unstructured.Unstructured{Object: vmMap}, extra, "", nil, nil
 }
 
-// returns false for all cases when backup might end up with a broken PVC snapshot
+// Progress reports on the status of an async native backup operation.
+func (p *VMBackupItemAction) Progress(operationID string, backup *v1.Backup) (velero.OperationProgress, error) {
+	if operationID == "" {
+		return velero.OperationProgress{}, fmt.Errorf("empty operation ID")
+	}
+	return nativebackup.CheckProgress(operationID, p.log)
+}
+
+// Cancel cancels an in-progress native backup and cleans up resources.
+func (p *VMBackupItemAction) Cancel(operationID string, backup *v1.Backup) error {
+	if operationID == "" {
+		return nil
+	}
+	return nativebackup.CancelAndCleanup(operationID, p.log)
+}
+
+// shouldUseNativeBackup determines if native KubeVirt backup should be used
+func (p *VMBackupItemAction) shouldUseNativeBackup(vm *kvcore.VirtualMachine, backup *v1.Backup) bool {
+	// Must be explicitly enabled via label
+	if !nativebackup.IsEnabled(backup) {
+		return false
+	}
+
+	// VM must be running (native backup requires QEMU/libvirt)
+	if !vm.Status.Created {
+		p.log.Infof("VM %s/%s is not running, falling back to CSI snapshot", vm.Namespace, vm.Name)
+		return false
+	}
+
+	// CRD must be installed
+	if !nativebackup.IsAvailable() {
+		p.log.Info("VirtualMachineBackup CRD not available, falling back to CSI snapshot")
+		return false
+	}
+
+	// No async operations during Finalize phase
+	if backup.Status.Phase == v1.BackupPhaseFinalizing ||
+		backup.Status.Phase == v1.BackupPhaseFinalizingPartiallyFailed {
+		p.log.Info("Backup in Finalize phase, skipping native backup")
+		return false
+	}
+
+	return true
+}
+
+// executeNativeBackup initiates a native KubeVirt backup and returns async operation info
+func (p *VMBackupItemAction) executeNativeBackup(
+	vm *kvcore.VirtualMachine,
+	backup *v1.Backup,
+	item runtime.Unstructured,
+	additionalItems []velero.ResourceIdentifier,
+) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+
+	crName := nativebackup.BackupCRName(backup.Name, vm.Name)
+	operationID := fmt.Sprintf("%s/%s", vm.Namespace, crName)
+
+	// Filter to persistent volumes only
+	persistentVolumes := nativebackup.FilterPersistentVolumes(vm.Spec.Template.Spec.Volumes)
+	if len(persistentVolumes) == 0 {
+		p.log.Infof("No persistent volumes on VM %s/%s, using CSI path", vm.Namespace, vm.Name)
+		vmMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
+		if err != nil {
+			return nil, nil, "", nil, errors.WithStack(err)
+		}
+		return &unstructured.Unstructured{Object: vmMap}, additionalItems, "", nil, nil
+	}
+
+	// Idempotency: check if CR already exists (Velero retry case)
+	exists, err := nativebackup.VMBackupExists(vm.Namespace, crName)
+	if err != nil {
+		p.log.WithError(err).Warn("Error checking existing backup CR, falling back to CSI")
+		return p.fallbackToCSI(vm, additionalItems)
+	}
+
+	if exists {
+		p.log.Infof("VirtualMachineBackup %s already exists (retry), reusing operation", crName)
+		util.AddAnnotation(item, nativebackup.BackupUsedAnnotation, "true")
+		util.AddAnnotation(item, nativebackup.BackupCRAnnotation, operationID)
+
+		// Still need to return the scratch PVC as postOperationItem
+		scratchName := nativebackup.ScratchPVCName(backup.Name, vm.Name)
+		postItems := []velero.ResourceIdentifier{{
+			GroupResource: schema.GroupResource{Resource: "persistentvolumeclaims"},
+			Namespace:     vm.Namespace,
+			Name:          scratchName,
+		}}
+
+		// Exclude native-backed PVCs from additional items
+		additionalItems = nativebackup.ExcludeNativeBackedPVCs(additionalItems, persistentVolumes)
+
+		vmMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
+		if err != nil {
+			return nil, nil, "", nil, errors.WithStack(err)
+		}
+		return &unstructured.Unstructured{Object: vmMap}, additionalItems, operationID, postItems, nil
+	}
+
+	// Create scratch PVC
+	scratchName, err := nativebackup.CreateScratchPVC(vm, backup, p.log)
+	if err != nil {
+		p.log.WithError(err).Warn("Scratch PVC creation failed, falling back to CSI")
+		return p.fallbackToCSI(vm, additionalItems)
+	}
+
+	// Resolve backup source (VM for full, Tracker for incremental)
+	source, forceFullBackup, err := nativebackup.ResolveSource(vm, backup, p.log)
+	if err != nil {
+		_ = nativebackup.CleanupScratchPVC(scratchName, vm.Namespace)
+		p.log.WithError(err).Warn("Source resolution failed, falling back to CSI")
+		return p.fallbackToCSI(vm, additionalItems)
+	}
+
+	// Detect guest agent for quiesce decision
+	skipQuiesce := nativebackup.ShouldSkipQuiesce(vm, backup, p.log)
+
+	// Create VirtualMachineBackup CR
+	err = nativebackup.CreateVMBackupCR(nativebackup.CreateParams{
+		Name:            crName,
+		Namespace:       vm.Namespace,
+		Source:          source,
+		PVCName:         scratchName,
+		Mode:            "Push",
+		SkipQuiesce:     skipQuiesce,
+		ForceFullBackup: forceFullBackup,
+	})
+	if err != nil {
+		_ = nativebackup.CleanupScratchPVC(scratchName, vm.Namespace)
+		p.log.WithError(err).Warn("VirtualMachineBackup CR creation failed, falling back to CSI")
+		return p.fallbackToCSI(vm, additionalItems)
+	}
+
+	p.log.Infof("Initiated native backup %s for VM %s/%s (source: %s/%s, skipQuiesce: %v, forceFullBackup: %v)",
+		crName, vm.Namespace, vm.Name, source.Kind, source.Name, skipQuiesce, forceFullBackup)
+
+	// Annotate VM with native backup metadata
+	util.AddAnnotation(item, nativebackup.BackupUsedAnnotation, "true")
+	util.AddAnnotation(item, nativebackup.BackupCRAnnotation, operationID)
+	util.AddAnnotation(item, nativebackup.TrackerAnnotation, nativebackup.TrackerName(vm.Name))
+	util.AddAnnotation(item, nativebackup.BackupVolumesAnnotation,
+		strings.Join(nativebackup.GetVolumeClaimNames(persistentVolumes), ","))
+
+	// Scratch PVC as postOperationItem — Velero snapshots it AFTER native backup completes
+	postItems := []velero.ResourceIdentifier{{
+		GroupResource: schema.GroupResource{Resource: "persistentvolumeclaims"},
+		Namespace:     vm.Namespace,
+		Name:          scratchName,
+	}}
+
+	// Exclude native-backed PVCs from additionalItems (prevent CSI double-snapshot)
+	additionalItems = nativebackup.ExcludeNativeBackedPVCs(additionalItems, persistentVolumes)
+
+	vmMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
+	if err != nil {
+		return nil, nil, "", nil, errors.WithStack(err)
+	}
+	return &unstructured.Unstructured{Object: vmMap}, additionalItems, operationID, postItems, nil
+}
+
+// fallbackToCSI returns the standard CSI snapshot path (sync, no native backup)
+func (p *VMBackupItemAction) fallbackToCSI(
+	vm *kvcore.VirtualMachine,
+	additionalItems []velero.ResourceIdentifier,
+) (runtime.Unstructured, []velero.ResourceIdentifier, string, []velero.ResourceIdentifier, error) {
+	vmMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
+	if err != nil {
+		return nil, nil, "", nil, errors.WithStack(err)
+	}
+	return &unstructured.Unstructured{Object: vmMap}, additionalItems, "", nil, nil
+}
+
+// canBeSafelyBackedUp returns false for cases when backup might end up with a broken PVC snapshot
 func (p *VMBackupItemAction) canBeSafelyBackedUp(vm *kvcore.VirtualMachine, backup *v1.Backup) (bool, error) {
-	isRuning := vm.Status.PrintableStatus == kvcore.VirtualMachineStatusStarting || vm.Status.PrintableStatus == kvcore.VirtualMachineStatusRunning
-	if !isRuning {
+	isRunning := vm.Status.PrintableStatus == kvcore.VirtualMachineStatusStarting || vm.Status.PrintableStatus == kvcore.VirtualMachineStatusRunning
+	if !isRunning {
 		return true, nil
 	}
 
@@ -188,4 +365,3 @@ func volumeInDVTemplates(volume kvcore.Volume, vm *kvcore.VirtualMachine) bool {
 
 	return false
 }
-

--- a/pkg/plugin/vm_backup_item_action.go
+++ b/pkg/plugin/vm_backup_item_action.go
@@ -211,8 +211,13 @@ func (p *VMBackupItemAction) executeNativeBackup(
 
 	if exists {
 		p.log.Infof("VirtualMachineBackup %s already exists (retry), reusing operation", crName)
-		util.AddAnnotation(item, nativebackup.BackupUsedAnnotation, "true")
-		util.AddAnnotation(item, nativebackup.BackupCRAnnotation, operationID)
+
+		// Add annotations to the VM struct so they survive ToUnstructured conversion
+		if vm.Annotations == nil {
+			vm.Annotations = make(map[string]string)
+		}
+		vm.Annotations[nativebackup.BackupUsedAnnotation] = "true"
+		vm.Annotations[nativebackup.BackupCRAnnotation] = operationID
 
 		// Still need to return the scratch PVC as postOperationItem
 		scratchName := nativebackup.ScratchPVCName(backup.Name, vm.Name)
@@ -242,7 +247,9 @@ func (p *VMBackupItemAction) executeNativeBackup(
 	// Resolve backup source (VM for full, Tracker for incremental)
 	source, forceFullBackup, err := nativebackup.ResolveSource(vm, backup, p.log)
 	if err != nil {
-		_ = nativebackup.CleanupScratchPVC(scratchName, vm.Namespace)
+		if cleanupErr := nativebackup.CleanupScratchPVC(scratchName, vm.Namespace); cleanupErr != nil {
+			p.log.WithError(cleanupErr).Warn("Failed to clean up scratch PVC after source resolution failure")
+		}
 		p.log.WithError(err).Warn("Source resolution failed, falling back to CSI")
 		return p.fallbackToCSI(vm, additionalItems)
 	}
@@ -261,7 +268,9 @@ func (p *VMBackupItemAction) executeNativeBackup(
 		ForceFullBackup: forceFullBackup,
 	})
 	if err != nil {
-		_ = nativebackup.CleanupScratchPVC(scratchName, vm.Namespace)
+		if cleanupErr := nativebackup.CleanupScratchPVC(scratchName, vm.Namespace); cleanupErr != nil {
+			p.log.WithError(cleanupErr).Warn("Failed to clean up scratch PVC after CR creation failure")
+		}
 		p.log.WithError(err).Warn("VirtualMachineBackup CR creation failed, falling back to CSI")
 		return p.fallbackToCSI(vm, additionalItems)
 	}
@@ -269,12 +278,14 @@ func (p *VMBackupItemAction) executeNativeBackup(
 	p.log.Infof("Initiated native backup %s for VM %s/%s (source: %s/%s, skipQuiesce: %v, forceFullBackup: %v)",
 		crName, vm.Namespace, vm.Name, source.Kind, source.Name, skipQuiesce, forceFullBackup)
 
-	// Annotate VM with native backup metadata
-	util.AddAnnotation(item, nativebackup.BackupUsedAnnotation, "true")
-	util.AddAnnotation(item, nativebackup.BackupCRAnnotation, operationID)
-	util.AddAnnotation(item, nativebackup.TrackerAnnotation, nativebackup.TrackerName(vm.Name))
-	util.AddAnnotation(item, nativebackup.BackupVolumesAnnotation,
-		strings.Join(nativebackup.GetVolumeClaimNames(persistentVolumes), ","))
+	// Annotate VM with native backup metadata (on the struct, not item, so it survives ToUnstructured)
+	if vm.Annotations == nil {
+		vm.Annotations = make(map[string]string)
+	}
+	vm.Annotations[nativebackup.BackupUsedAnnotation] = "true"
+	vm.Annotations[nativebackup.BackupCRAnnotation] = operationID
+	vm.Annotations[nativebackup.TrackerAnnotation] = nativebackup.TrackerName(vm.Name)
+	vm.Annotations[nativebackup.BackupVolumesAnnotation] = strings.Join(nativebackup.GetVolumeClaimNames(persistentVolumes), ",")
 
 	// Scratch PVC as postOperationItem — Velero snapshots it AFTER native backup completes
 	postItems := []velero.ResourceIdentifier{{
@@ -357,6 +368,9 @@ var isVMIExcludedByLabel = func(vm *kvcore.VirtualMachine) (bool, error) {
 }
 
 func volumeInDVTemplates(volume kvcore.Volume, vm *kvcore.VirtualMachine) bool {
+	if volume.VolumeSource.DataVolume == nil {
+		return false
+	}
 	for _, template := range vm.Spec.DataVolumeTemplates {
 		if template.Name == volume.VolumeSource.DataVolume.Name {
 			return true

--- a/pkg/plugin/vm_backup_item_action_test.go
+++ b/pkg/plugin/vm_backup_item_action_test.go
@@ -559,7 +559,7 @@ func TestVMBackupAction(t *testing.T) {
 			util.ListPods = func(name, ns string) (*k8sv1.PodList, error) {
 				return &k8sv1.PodList{}, nil
 			}
-			_, extra, err := action.Execute(&tc.vm, &tc.backup)
+			_, extra, _, _, err := action.Execute(&tc.vm, &tc.backup)
 
 			if tc.errorExpected {
 				assert.Error(t, err)

--- a/pkg/plugin/vm_delete_item_action.go
+++ b/pkg/plugin/vm_delete_item_action.go
@@ -76,8 +76,9 @@ func (p *VMDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteInput)
 		return nil
 	}
 
-	ns, name := nativebackup.ParseOperationID(crRef)
-	if ns == "" || name == "" {
+	ns, name, err := nativebackup.ParseOperationID(crRef)
+	if err != nil {
+		p.log.WithError(err).Warn("Invalid native backup CR reference annotation")
 		return nil
 	}
 

--- a/pkg/plugin/vm_delete_item_action.go
+++ b/pkg/plugin/vm_delete_item_action.go
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package plugin
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util/nativebackup"
+)
+
+// VMDeleteItemAction cleans up native backup artifacts when a Velero backup is deleted.
+type VMDeleteItemAction struct {
+	log logrus.FieldLogger
+}
+
+// NewVMDeleteItemAction instantiates a VMDeleteItemAction.
+func NewVMDeleteItemAction(log logrus.FieldLogger) *VMDeleteItemAction {
+	return &VMDeleteItemAction{log: log}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *VMDeleteItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{
+			"VirtualMachine",
+		},
+	}, nil
+}
+
+// Execute cleans up native backup CRs and scratch PVCs when a Velero backup is deleted.
+func (p *VMDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteInput) error {
+	p.log.Info("Executing VMDeleteItemAction")
+
+	if input == nil || input.Item == nil {
+		return nil
+	}
+
+	metadata, err := meta.Accessor(input.Item)
+	if err != nil {
+		return nil
+	}
+
+	annotations := metadata.GetAnnotations()
+	if annotations == nil {
+		return nil
+	}
+
+	// Check if this VM used native backup
+	if annotations[nativebackup.BackupUsedAnnotation] != "true" {
+		return nil
+	}
+
+	crRef := annotations[nativebackup.BackupCRAnnotation]
+	if crRef == "" {
+		return nil
+	}
+
+	ns, name := nativebackup.ParseOperationID(crRef)
+	if ns == "" || name == "" {
+		return nil
+	}
+
+	p.log.Infof("Cleaning up native backup artifacts for VM %s/%s (CR: %s)",
+		metadata.GetNamespace(), metadata.GetName(), crRef)
+
+	// Delete VirtualMachineBackup CR if it still exists
+	if err := nativebackup.DeleteVMBackupCR(ns, name); err != nil {
+		p.log.WithError(err).Warn("Failed to delete VirtualMachineBackup CR during backup deletion")
+	}
+
+	// Delete orphaned scratch PVCs
+	if err := nativebackup.CleanupScratchPVCsByBackup(ns, name); err != nil {
+		p.log.WithError(err).Warn("Failed to clean up scratch PVCs during backup deletion")
+	}
+
+	// Garbage collect stale scratch PVCs in this namespace
+	_ = nativebackup.GarbageCollectStaleScratchPVCs(ns, p.log)
+
+	return nil
+}
+
+// Ensure VMDeleteItemAction implements the interface at compile time
+var _ velero.DeleteItemAction = &VMDeleteItemAction{}
+
+// isNativeBackupVM checks if a runtime.Unstructured VM has native backup annotations
+func isNativeBackupVM(item runtime.Unstructured) bool {
+	metadata, err := meta.Accessor(item)
+	if err != nil {
+		return false
+	}
+	annotations := metadata.GetAnnotations()
+	return annotations != nil && annotations[nativebackup.BackupUsedAnnotation] == "true"
+}

--- a/pkg/plugin/vm_delete_item_action.go
+++ b/pkg/plugin/vm_delete_item_action.go
@@ -95,7 +95,9 @@ func (p *VMDeleteItemAction) Execute(input *velero.DeleteItemActionExecuteInput)
 	}
 
 	// Garbage collect stale scratch PVCs in this namespace
-	_ = nativebackup.GarbageCollectStaleScratchPVCs(ns, p.log)
+	if err := nativebackup.GarbageCollectStaleScratchPVCs(ns, p.log); err != nil {
+		p.log.WithError(err).Warn("Failed to garbage collect stale scratch PVCs")
+	}
 
 	return nil
 }

--- a/pkg/plugin/vm_item_block_action.go
+++ b/pkg/plugin/vm_item_block_action.go
@@ -1,0 +1,73 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package plugin
+
+import (
+	"github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util/kvgraph"
+)
+
+// VMItemBlockAction ensures that a VirtualMachine and all its related resources
+// (VMI, PVCs, DataVolumes, launcher pod, secrets, etc.) are processed as an
+// atomic block during backup. This prevents partial backups where the VM is
+// captured but a PVC is processed in a separate parallel thread.
+type VMItemBlockAction struct {
+	log logrus.FieldLogger
+}
+
+// NewVMItemBlockAction instantiates a VMItemBlockAction.
+func NewVMItemBlockAction(log logrus.FieldLogger) *VMItemBlockAction {
+	return &VMItemBlockAction{log: log}
+}
+
+// Name returns the name of this IBA (required by v1 interface).
+func (p *VMItemBlockAction) Name() string {
+	return "kubevirt-velero-plugin/block-vm-action"
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *VMItemBlockAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{
+			"VirtualMachine",
+		},
+	}, nil
+}
+
+// GetRelatedItems returns all resources that must be backed up atomically with this VM.
+// Uses the same dependency graph as the BackupItemAction.
+func (p *VMItemBlockAction) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup) ([]velero.ResourceIdentifier, error) {
+	p.log.Info("Computing VM item block dependencies")
+
+	resources, err := kvgraph.NewObjectBackupGraph(item)
+	if err != nil {
+		// Non-fatal: return empty list, backup can still proceed without block guarantee
+		p.log.WithError(err).Warn("Failed to compute VM backup graph for block action")
+		return []velero.ResourceIdentifier{}, nil
+	}
+
+	p.log.Infof("VM item block contains %d related resources", len(resources))
+	return resources, nil
+}

--- a/pkg/plugin/vm_restore_item_action.go
+++ b/pkg/plugin/vm_restore_item_action.go
@@ -21,26 +21,39 @@ package plugin
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	v2 "github.com/vmware-tanzu/velero/pkg/plugin/velero/restoreitemaction/v2"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	corev1 "k8s.io/api/core/v1"
 	kvcore "kubevirt.io/api/core/v1"
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
 	"kubevirt.io/kubevirt-velero-plugin/pkg/util/kvgraph"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util/nativebackup"
 )
 
-// VIMRestorePlugin is a VMI restore item action plugin for Velero (duh!)
+// VMRestorePlugin is a v2 VM restore item action plugin for Velero.
+// It supports AreAdditionalItemsReady to wait for PVCs to be bound before
+// the VM is created by the API server.
 type VMRestorePlugin struct {
 	log logrus.FieldLogger
 }
 
-// NewVMRestorePlugin instantiates a RestorePlugin.
+// NewVMRestoreItemAction instantiates a RestorePlugin.
 func NewVMRestoreItemAction(log logrus.FieldLogger) *VMRestorePlugin {
 	return &VMRestorePlugin{log: log}
+}
+
+// Name returns the name of this RIA (required by v2 interface).
+func (p *VMRestorePlugin) Name() string {
+	return "kubevirt-velero-plugin/restore-vm-action"
 }
 
 // AppliesTo returns information about which resources this action should be invoked for.
@@ -52,9 +65,13 @@ func (p *VMRestorePlugin) AppliesTo() (velero.ResourceSelector, error) {
 	}, nil
 }
 
-// Execute – If VM was running, it must be restored as stopped
+// Execute restores a VirtualMachine with optional modifications:
+// - Run strategy override
+// - MAC address clearing
+// - Firmware UUID regeneration
+// - Native backup volume remapping
 func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
-	p.log.Info("Running VMRestorePlugin")
+	p.log.Info("Running VMRestorePlugin (v2)")
 
 	if input == nil {
 		return nil, fmt.Errorf("input object nil!")
@@ -81,6 +98,21 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 		util.GenerateNewFirmwareUUID(&vm.Spec.Template.Spec, vm.Name, vm.Namespace, string(vm.UID))
 	}
 
+	// Handle native backup volume remapping
+	if ann := vm.GetAnnotations(); ann != nil && ann[nativebackup.BackupUsedAnnotation] == "true" {
+		p.log.Info("VM was backed up using native KubeVirt backup, annotations preserved for restore")
+		// The scratch PVC is restored by Velero with its original name.
+		// Volume references already point to the correct PVCs in the backup.
+		// Clean up native backup annotations to avoid confusion on the restored VM.
+		delete(ann, nativebackup.BackupUsedAnnotation)
+		delete(ann, nativebackup.BackupCRAnnotation)
+		delete(ann, nativebackup.BackupTypeAnnotation)
+		delete(ann, nativebackup.BackupCheckpointAnnotation)
+		delete(ann, nativebackup.BackupVolumesAnnotation)
+		delete(ann, nativebackup.TrackerAnnotation)
+		vm.SetAnnotations(ann)
+	}
+
 	item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(vm)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -92,6 +124,48 @@ func (p *VMRestorePlugin) Execute(input *velero.RestoreItemActionExecuteInput) (
 		return nil, errors.WithStack(err)
 	}
 
+	// v2: Wait for PVCs to be ready before VM is created
+	if len(output.AdditionalItems) > 0 {
+		output.WaitForAdditionalItems = true
+		output.AdditionalItemsReadyTimeout = 10 * time.Minute
+	}
+
 	return output, nil
 }
 
+// AreAdditionalItemsReady checks if all PVCs in the additional items are bound.
+// This prevents the VM from being created before its storage is ready.
+func (p *VMRestorePlugin) AreAdditionalItemsReady(
+	additionalItems []velero.ResourceIdentifier,
+	restore *v1.Restore,
+) (bool, error) {
+	for _, item := range additionalItems {
+		if item.Resource != "persistentvolumeclaims" {
+			continue
+		}
+
+		pvc, err := util.GetPVC(item.Namespace, item.Name)
+		if err != nil {
+			p.log.Infof("PVC %s/%s not yet available: %v", item.Namespace, item.Name, err)
+			return false, nil
+		}
+
+		if pvc.Status.Phase != corev1.ClaimBound {
+			p.log.Infof("PVC %s/%s not yet bound (phase: %s)", item.Namespace, item.Name, pvc.Status.Phase)
+			return false, nil
+		}
+	}
+
+	p.log.Info("All additional PVCs are bound, VM restore can proceed")
+	return true, nil
+}
+
+// Progress reports on async restore operations (not used for VM restore).
+func (p *VMRestorePlugin) Progress(operationID string, restore *v1.Restore) (velero.OperationProgress, error) {
+	return velero.OperationProgress{}, v2.AsyncOperationsNotSupportedError()
+}
+
+// Cancel cancels an async restore operation (not used for VM restore).
+func (p *VMRestorePlugin) Cancel(operationID string, restore *v1.Restore) error {
+	return nil
+}

--- a/pkg/util/nativebackup/agent.go
+++ b/pkg/util/nativebackup/agent.go
@@ -1,0 +1,84 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	kvcore "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+// ShouldSkipQuiesce determines whether filesystem quiescing should be skipped.
+// Returns true if:
+// - The user explicitly set the skip-quiesce label
+// - autoSkipQuiesceNoAgent is enabled and the guest agent is not connected
+var ShouldSkipQuiesce = func(vm *kvcore.VirtualMachine, backup *v1.Backup, log logrus.FieldLogger) bool {
+	// Explicit user override
+	if metav1.HasLabel(backup.ObjectMeta, SkipQuiesceLabel) {
+		log.Infof("Skip quiesce explicitly requested for VM %s/%s", vm.Namespace, vm.Name)
+		return true
+	}
+
+	cfg := LoadConfig(backup)
+	if !cfg.AutoSkipQuiesceNoAgent {
+		return false
+	}
+
+	// Check VMI conditions for AgentConnected
+	if !isGuestAgentConnected(vm.Namespace, vm.Name, log) {
+		log.Warnf("QEMU guest agent not connected for VM %s/%s, auto-skipping quiesce", vm.Namespace, vm.Name)
+		return true
+	}
+
+	return false
+}
+
+// isGuestAgentConnected checks if the QEMU guest agent is reported as connected
+// in the VMI's status conditions.
+func isGuestAgentConnected(ns, name string, log logrus.FieldLogger) bool {
+	kvClient, err := util.GetKubeVirtclient()
+	if err != nil {
+		log.WithError(err).Warn("Failed to get KubeVirt client for agent detection")
+		return false
+	}
+
+	vmi, err := (*kvClient).VirtualMachineInstance(ns).Get(
+		context.TODO(), name, metav1.GetOptions{},
+	)
+	if err != nil {
+		log.WithError(err).Warnf("Failed to get VMI %s/%s for agent detection", ns, name)
+		return false
+	}
+
+	for _, c := range vmi.Status.Conditions {
+		if c.Type == kvcore.VirtualMachineInstanceAgentConnected {
+			return c.Status == corev1.ConditionTrue
+		}
+	}
+
+	// No AgentConnected condition found at all
+	return false
+}

--- a/pkg/util/nativebackup/agent.go
+++ b/pkg/util/nativebackup/agent.go
@@ -20,7 +20,7 @@
 package nativebackup
 
 import (
-	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +48,14 @@ var ShouldSkipQuiesce = func(vm *kvcore.VirtualMachine, backup *v1.Backup, log l
 	}
 
 	// Check VMI conditions for AgentConnected
-	if !isGuestAgentConnected(vm.Namespace, vm.Name, log) {
+	connected, err := isGuestAgentConnected(vm.Namespace, vm.Name)
+	if err != nil {
+		// API error — cannot determine agent status. Default to skipping quiesce
+		// (attempting quiesce without agent would fail the entire backup).
+		log.WithError(err).Warnf("Failed to check guest agent status for VM %s/%s, skipping quiesce to avoid backup failure", vm.Namespace, vm.Name)
+		return true
+	}
+	if !connected {
 		log.Warnf("QEMU guest agent not connected for VM %s/%s, auto-skipping quiesce", vm.Namespace, vm.Name)
 		return true
 	}
@@ -57,28 +64,28 @@ var ShouldSkipQuiesce = func(vm *kvcore.VirtualMachine, backup *v1.Backup, log l
 }
 
 // isGuestAgentConnected checks if the QEMU guest agent is reported as connected
-// in the VMI's status conditions.
-func isGuestAgentConnected(ns, name string, log logrus.FieldLogger) bool {
+// in the VMI's status conditions. Returns an error if the VMI cannot be retrieved.
+func isGuestAgentConnected(ns, name string) (bool, error) {
 	kvClient, err := util.GetKubeVirtclient()
 	if err != nil {
-		log.WithError(err).Warn("Failed to get KubeVirt client for agent detection")
-		return false
+		return false, fmt.Errorf("failed to get KubeVirt client: %w", err)
 	}
 
+	ctx, cancel := apiContext()
+	defer cancel()
 	vmi, err := (*kvClient).VirtualMachineInstance(ns).Get(
-		context.TODO(), name, metav1.GetOptions{},
+		ctx, name, metav1.GetOptions{},
 	)
 	if err != nil {
-		log.WithError(err).Warnf("Failed to get VMI %s/%s for agent detection", ns, name)
-		return false
+		return false, fmt.Errorf("failed to get VMI %s/%s: %w", ns, name, err)
 	}
 
 	for _, c := range vmi.Status.Conditions {
 		if c.Type == kvcore.VirtualMachineInstanceAgentConnected {
-			return c.Status == corev1.ConditionTrue
+			return c.Status == corev1.ConditionTrue, nil
 		}
 	}
 
 	// No AgentConnected condition found at all
-	return false
+	return false, nil
 }

--- a/pkg/util/nativebackup/backup.go
+++ b/pkg/util/nativebackup/backup.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,13 +66,19 @@ func BackupCRName(veleroBackupName, vmName string) string {
 	return name
 }
 
-// ParseOperationID splits a "namespace/name" operation ID
-func ParseOperationID(operationID string) (string, string) {
+// apiContext returns a context with a 30-second timeout for Kubernetes API calls.
+func apiContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), 30*time.Second)
+}
+
+// ParseOperationID splits a "namespace/name" operation ID.
+// Returns an error if the format is invalid.
+func ParseOperationID(operationID string) (string, string, error) {
 	parts := strings.SplitN(operationID, "/", 2)
-	if len(parts) != 2 {
-		return "", operationID
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("invalid operation ID %q: expected namespace/name format", operationID)
 	}
-	return parts[0], parts[1]
+	return parts[0], parts[1], nil
 }
 
 // CreateVMBackupCR creates a VirtualMachineBackup CR using the dynamic client
@@ -113,8 +120,10 @@ var CreateVMBackupCR = func(params CreateParams) error {
 		},
 	}
 
+	ctx, cancel := apiContext()
+	defer cancel()
 	_, err = client.Resource(vmBackupGVR).Namespace(params.Namespace).Create(
-		context.TODO(), obj, metav1.CreateOptions{},
+		ctx, obj, metav1.CreateOptions{},
 	)
 	return err
 }
@@ -126,8 +135,10 @@ var GetVMBackup = func(ns, name string) (*unstructured.Unstructured, error) {
 		return nil, err
 	}
 
+	ctx, cancel := apiContext()
+	defer cancel()
 	return client.Resource(vmBackupGVR).Namespace(ns).Get(
-		context.TODO(), name, metav1.GetOptions{},
+		ctx, name, metav1.GetOptions{},
 	)
 }
 
@@ -138,8 +149,10 @@ var DeleteVMBackupCR = func(ns, name string) error {
 		return err
 	}
 
+	ctx, cancel := apiContext()
+	defer cancel()
 	return client.Resource(vmBackupGVR).Namespace(ns).Delete(
-		context.TODO(), name, metav1.DeleteOptions{},
+		ctx, name, metav1.DeleteOptions{},
 	)
 }
 

--- a/pkg/util/nativebackup/backup.go
+++ b/pkg/util/nativebackup/backup.go
@@ -1,0 +1,167 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var vmBackupGVR = schema.GroupVersionResource{
+	Group:    "backup.kubevirt.io",
+	Version:  "v1alpha1",
+	Resource: "virtualmachinebackups",
+}
+
+// SourceRef identifies the source for a VirtualMachineBackup
+type SourceRef struct {
+	APIGroup string // "kubevirt.io" or "backup.kubevirt.io"
+	Kind     string // "VirtualMachine" or "VirtualMachineBackupTracker"
+	Name     string
+}
+
+// CreateParams contains parameters for creating a VirtualMachineBackup CR
+type CreateParams struct {
+	Name            string
+	Namespace       string
+	Source          SourceRef
+	PVCName         string
+	Mode            string // "Push" or "Pull"
+	SkipQuiesce     bool
+	ForceFullBackup bool
+}
+
+// BackupCRName returns a deterministic name for the VirtualMachineBackup CR
+func BackupCRName(veleroBackupName, vmName string) string {
+	name := fmt.Sprintf("velero-%s-%s", veleroBackupName, vmName)
+	if len(name) > 253 {
+		name = name[:253]
+	}
+	return name
+}
+
+// ParseOperationID splits a "namespace/name" operation ID
+func ParseOperationID(operationID string) (string, string) {
+	parts := strings.SplitN(operationID, "/", 2)
+	if len(parts) != 2 {
+		return "", operationID
+	}
+	return parts[0], parts[1]
+}
+
+// CreateVMBackupCR creates a VirtualMachineBackup CR using the dynamic client
+var CreateVMBackupCR = func(params CreateParams) error {
+	client, err := getDynamicClient()
+	if err != nil {
+		return fmt.Errorf("failed to get dynamic client: %w", err)
+	}
+
+	spec := map[string]interface{}{
+		"source": map[string]interface{}{
+			"apiGroup": params.Source.APIGroup,
+			"kind":     params.Source.Kind,
+			"name":     params.Source.Name,
+		},
+		"mode":    params.Mode,
+		"pvcName": params.PVCName,
+	}
+
+	if params.SkipQuiesce {
+		spec["skipQuiesce"] = true
+	}
+	if params.ForceFullBackup {
+		spec["forceFullBackup"] = true
+	}
+
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "backup.kubevirt.io/v1alpha1",
+			"kind":       "VirtualMachineBackup",
+			"metadata": map[string]interface{}{
+				"name":      params.Name,
+				"namespace": params.Namespace,
+				"labels": map[string]interface{}{
+					ScratchPVCBackupLabel: params.Name,
+				},
+			},
+			"spec": spec,
+		},
+	}
+
+	_, err = client.Resource(vmBackupGVR).Namespace(params.Namespace).Create(
+		context.TODO(), obj, metav1.CreateOptions{},
+	)
+	return err
+}
+
+// GetVMBackup retrieves a VirtualMachineBackup CR by namespace and name
+var GetVMBackup = func(ns, name string) (*unstructured.Unstructured, error) {
+	client, err := getDynamicClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return client.Resource(vmBackupGVR).Namespace(ns).Get(
+		context.TODO(), name, metav1.GetOptions{},
+	)
+}
+
+// DeleteVMBackupCR deletes a VirtualMachineBackup CR
+var DeleteVMBackupCR = func(ns, name string) error {
+	client, err := getDynamicClient()
+	if err != nil {
+		return err
+	}
+
+	return client.Resource(vmBackupGVR).Namespace(ns).Delete(
+		context.TODO(), name, metav1.DeleteOptions{},
+	)
+}
+
+// VMBackupExists checks if a VirtualMachineBackup CR already exists (for idempotency)
+func VMBackupExists(ns, name string) (bool, error) {
+	_, err := GetVMBackup(ns, name)
+	if err == nil {
+		return true, nil
+	}
+	if k8serrors.IsNotFound(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func getDynamicClient() (dynamic.Interface, error) {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	configOverrides := &clientcmd.ConfigOverrides{}
+	kubeConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides)
+	clientConfig, err := kubeConfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(clientConfig)
+}

--- a/pkg/util/nativebackup/config.go
+++ b/pkg/util/nativebackup/config.go
@@ -57,6 +57,9 @@ const (
 	// Labels on source PVCs during native backup to prevent CSI double-snapshot
 	NativeBackedPVCLabel = "velero.kubevirt.io/native-backed"
 
+	// Annotation on tracker to count incremental backups since last full
+	IncrementalCountAnnotation = "velero.kubevirt.io/incremental-count"
+
 	// ConfigMap defaults
 	ConfigMapName      = "kubevirt-velero-plugin-config"
 	ConfigMapNamespace = "velero"

--- a/pkg/util/nativebackup/config.go
+++ b/pkg/util/nativebackup/config.go
@@ -1,0 +1,176 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+const (
+	// Labels on Velero Backup object to control behavior
+	NativeBackupLabel   = "velero.kubevirt.io/native-backup"
+	IncrementalLabel    = "velero.kubevirt.io/incremental-backup"
+	SkipQuiesceLabel    = "velero.kubevirt.io/skip-quiesce"
+	ScratchStorageLabel = "velero.kubevirt.io/scratch-storage-class"
+	ConcurrencyLabel    = "velero.kubevirt.io/native-backup-concurrency"
+	ForceFullEveryLabel = "velero.kubevirt.io/force-full-every-n"
+
+	// Annotations added to VM during backup
+	BackupUsedAnnotation       = "velero.kubevirt.io/native-backup-used"
+	BackupCRAnnotation         = "velero.kubevirt.io/native-backup-cr"
+	BackupTypeAnnotation       = "velero.kubevirt.io/native-backup-type"
+	BackupCheckpointAnnotation = "velero.kubevirt.io/native-backup-checkpoint"
+	BackupVolumesAnnotation    = "velero.kubevirt.io/native-backup-volumes"
+	TrackerAnnotation          = "velero.kubevirt.io/backup-tracker"
+
+	// Labels/annotations on scratch PVCs
+	NativeBackupPVCLabel     = "velero.kubevirt.io/native-backup-pvc"
+	ScratchPVCBackupLabel    = "velero.kubevirt.io/scratch-for-backup"
+	OriginalVolumeAnnotation = "velero.kubevirt.io/original-volume-name"
+	OriginalPVCAnnotation    = "velero.kubevirt.io/original-pvc-name"
+	ScratchPVCTTLAnnotation  = "velero.kubevirt.io/scratch-pvc-ttl"
+
+	// Labels on source PVCs during native backup to prevent CSI double-snapshot
+	NativeBackedPVCLabel = "velero.kubevirt.io/native-backed"
+
+	// ConfigMap defaults
+	ConfigMapName      = "kubevirt-velero-plugin-config"
+	ConfigMapNamespace = "velero"
+)
+
+// Config holds plugin configuration from ConfigMap + label overrides
+type Config struct {
+	NativeBackupEnabled        bool
+	IncrementalEnabled         bool
+	DefaultScratchStorageClass string
+	MaxConcurrentBackups       int
+	ForceFullEveryN            int
+	BackupTimeout              time.Duration
+	AutoSkipQuiesceNoAgent     bool
+}
+
+// DefaultConfig returns configuration defaults
+func DefaultConfig() Config {
+	return Config{
+		NativeBackupEnabled:        false,
+		IncrementalEnabled:         false,
+		DefaultScratchStorageClass: "",
+		MaxConcurrentBackups:       0,
+		ForceFullEveryN:            0,
+		BackupTimeout:              30 * time.Minute,
+		AutoSkipQuiesceNoAgent:     true,
+	}
+}
+
+// LoadConfig reads configuration from the ConfigMap and overrides with Backup labels
+func LoadConfig(backup *v1.Backup) Config {
+	cfg := DefaultConfig()
+
+	// Read from ConfigMap (best-effort)
+	cfg = loadConfigMap(cfg)
+
+	// Override with Backup labels
+	if backup != nil {
+		labels := backup.GetLabels()
+		if labels != nil {
+			if _, ok := labels[NativeBackupLabel]; ok {
+				cfg.NativeBackupEnabled = true
+			}
+			if _, ok := labels[IncrementalLabel]; ok {
+				cfg.IncrementalEnabled = true
+			}
+			if sc, ok := labels[ScratchStorageLabel]; ok && sc != "" {
+				cfg.DefaultScratchStorageClass = sc
+			}
+			if v, ok := labels[ConcurrencyLabel]; ok {
+				if n, err := strconv.Atoi(v); err == nil && n > 0 {
+					cfg.MaxConcurrentBackups = n
+				}
+			}
+			if v, ok := labels[ForceFullEveryLabel]; ok {
+				if n, err := strconv.Atoi(v); err == nil && n > 0 {
+					cfg.ForceFullEveryN = n
+				}
+			}
+		}
+	}
+
+	return cfg
+}
+
+// IsEnabled returns true if native backup is enabled for this backup
+func IsEnabled(backup *v1.Backup) bool {
+	if backup == nil {
+		return false
+	}
+	return metav1.HasLabel(backup.ObjectMeta, NativeBackupLabel)
+}
+
+// loadConfigMap reads defaults from the plugin ConfigMap (best-effort)
+func loadConfigMap(cfg Config) Config {
+	client, err := util.GetK8sClient()
+	if err != nil {
+		return cfg
+	}
+
+	cm, err := client.CoreV1().ConfigMaps(ConfigMapNamespace).Get(
+		context.TODO(), ConfigMapName, metav1.GetOptions{},
+	)
+	if err != nil {
+		return cfg
+	}
+
+	if v, ok := cm.Data["nativeBackupEnabled"]; ok && v == "true" {
+		cfg.NativeBackupEnabled = true
+	}
+	if v, ok := cm.Data["incrementalBackupEnabled"]; ok && v == "true" {
+		cfg.IncrementalEnabled = true
+	}
+	if v, ok := cm.Data["defaultScratchStorageClass"]; ok && v != "" {
+		cfg.DefaultScratchStorageClass = v
+	}
+	if v, ok := cm.Data["maxConcurrentBackups"]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.MaxConcurrentBackups = n
+		}
+	}
+	if v, ok := cm.Data["forceFullEveryN"]; ok {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			cfg.ForceFullEveryN = n
+		}
+	}
+	if v, ok := cm.Data["backupTimeout"]; ok {
+		if d, err := time.ParseDuration(v); err == nil {
+			cfg.BackupTimeout = d
+		}
+	}
+	if v, ok := cm.Data["autoSkipQuiesceWithoutAgent"]; ok {
+		cfg.AutoSkipQuiesceNoAgent = v == "true"
+	}
+
+	return cfg
+}

--- a/pkg/util/nativebackup/detect.go
+++ b/pkg/util/nativebackup/detect.go
@@ -1,0 +1,70 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"sync"
+
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+var (
+	crdCheckOnce sync.Once
+	crdAvailable bool
+)
+
+// IsAvailable checks if the VirtualMachineBackup CRD is installed on the cluster.
+// The result is cached for the lifetime of the plugin process.
+func IsAvailable() bool {
+	crdCheckOnce.Do(func() {
+		crdAvailable = detectCRD()
+	})
+	return crdAvailable
+}
+
+// ResetDetectionCache allows tests to reset the CRD detection cache
+var ResetDetectionCache = func() {
+	crdCheckOnce = sync.Once{}
+	crdAvailable = false
+}
+
+func detectCRD() bool {
+	client, err := util.GetK8sClient()
+	if err != nil {
+		return false
+	}
+
+	_, resources, err := client.Discovery().ServerGroupsAndResources()
+	if err != nil {
+		return false
+	}
+
+	for _, list := range resources {
+		if list.GroupVersion == "backup.kubevirt.io/v1alpha1" {
+			for _, r := range list.APIResources {
+				if r.Kind == "VirtualMachineBackup" {
+					return true
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/util/nativebackup/nativebackup_test.go
+++ b/pkg/util/nativebackup/nativebackup_test.go
@@ -95,13 +95,22 @@ func TestTrackerName(t *testing.T) {
 }
 
 func TestParseOperationID(t *testing.T) {
-	ns, name := ParseOperationID("default/velero-backup-vm1")
+	ns, name, err := ParseOperationID("default/velero-backup-vm1")
+	assert.NoError(t, err)
 	assert.Equal(t, "default", ns)
 	assert.Equal(t, "velero-backup-vm1", name)
 
-	ns, name = ParseOperationID("no-slash")
-	assert.Equal(t, "", ns)
-	assert.Equal(t, "no-slash", name)
+	_, _, err = ParseOperationID("no-slash")
+	assert.Error(t, err)
+
+	_, _, err = ParseOperationID("")
+	assert.Error(t, err)
+
+	_, _, err = ParseOperationID("/name-only")
+	assert.Error(t, err)
+
+	_, _, err = ParseOperationID("ns-only/")
+	assert.Error(t, err)
 }
 
 func TestFilterPersistentVolumes(t *testing.T) {
@@ -269,6 +278,40 @@ func TestLoadConfig(t *testing.T) {
 	assert.Equal(t, "fast-ssd", cfg.DefaultScratchStorageClass)
 	assert.Equal(t, 3, cfg.MaxConcurrentBackups)
 	assert.Equal(t, 5, cfg.ForceFullEveryN)
+}
+
+func TestGetIncrementalCount(t *testing.T) {
+	// No annotations
+	tracker := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{},
+		},
+	}
+	assert.Equal(t, 0, getIncrementalCount(tracker))
+
+	// With annotation set to 3
+	tracker = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					IncrementalCountAnnotation: "3",
+				},
+			},
+		},
+	}
+	assert.Equal(t, 3, getIncrementalCount(tracker))
+
+	// Invalid annotation value
+	tracker = &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"annotations": map[string]interface{}{
+					IncrementalCountAnnotation: "bad",
+				},
+			},
+		},
+	}
+	assert.Equal(t, 0, getIncrementalCount(tracker))
 }
 
 func TestGetBackupMetadata(t *testing.T) {

--- a/pkg/util/nativebackup/nativebackup_test.go
+++ b/pkg/util/nativebackup/nativebackup_test.go
@@ -1,0 +1,298 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kvcore "kubevirt.io/api/core/v1"
+)
+
+func TestIsEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		backup   *v1.Backup
+		expected bool
+	}{
+		{
+			name:     "nil backup",
+			backup:   nil,
+			expected: false,
+		},
+		{
+			name: "backup without label",
+			backup: &v1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "backup with native-backup label",
+			backup: &v1.Backup{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						NativeBackupLabel: "true",
+					},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsEnabled(tt.backup)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBackupCRName(t *testing.T) {
+	assert.Equal(t, "velero-my-backup-my-vm", BackupCRName("my-backup", "my-vm"))
+
+	// Test length limit
+	longName := ""
+	for i := 0; i < 300; i++ {
+		longName += "a"
+	}
+	result := BackupCRName(longName, "vm")
+	assert.LessOrEqual(t, len(result), 253)
+}
+
+func TestScratchPVCName(t *testing.T) {
+	assert.Equal(t, "scratch-my-backup-my-vm", ScratchPVCName("my-backup", "my-vm"))
+}
+
+func TestTrackerName(t *testing.T) {
+	assert.Equal(t, "my-vm-backup-tracker", TrackerName("my-vm"))
+}
+
+func TestParseOperationID(t *testing.T) {
+	ns, name := ParseOperationID("default/velero-backup-vm1")
+	assert.Equal(t, "default", ns)
+	assert.Equal(t, "velero-backup-vm1", name)
+
+	ns, name = ParseOperationID("no-slash")
+	assert.Equal(t, "", ns)
+	assert.Equal(t, "no-slash", name)
+}
+
+func TestFilterPersistentVolumes(t *testing.T) {
+	volumes := []kvcore.Volume{
+		{
+			Name: "rootdisk",
+			VolumeSource: kvcore.VolumeSource{
+				DataVolume: &kvcore.DataVolumeSource{Name: "rootdisk-dv"},
+			},
+		},
+		{
+			Name: "datadisk",
+			VolumeSource: kvcore.VolumeSource{
+				PersistentVolumeClaim: &kvcore.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-pvc"},
+				},
+			},
+		},
+		{
+			Name: "cloudinit",
+			VolumeSource: kvcore.VolumeSource{
+				CloudInitNoCloud: &kvcore.CloudInitNoCloudSource{UserData: "test"},
+			},
+		},
+		{
+			Name: "configmap",
+			VolumeSource: kvcore.VolumeSource{
+				ConfigMap: &kvcore.ConfigMapVolumeSource{},
+			},
+		},
+	}
+
+	persistent := FilterPersistentVolumes(volumes)
+	assert.Len(t, persistent, 2)
+	assert.Equal(t, "rootdisk", persistent[0].Name)
+	assert.Equal(t, "datadisk", persistent[1].Name)
+}
+
+func TestGetVolumeClaimNames(t *testing.T) {
+	volumes := []kvcore.Volume{
+		{
+			Name: "rootdisk",
+			VolumeSource: kvcore.VolumeSource{
+				DataVolume: &kvcore.DataVolumeSource{Name: "rootdisk-dv"},
+			},
+		},
+		{
+			Name: "datadisk",
+			VolumeSource: kvcore.VolumeSource{
+				PersistentVolumeClaim: &kvcore.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{ClaimName: "data-pvc"},
+				},
+			},
+		},
+	}
+
+	names := GetVolumeClaimNames(volumes)
+	assert.Contains(t, names, "rootdisk-dv")
+	assert.Contains(t, names, "data-pvc")
+}
+
+func TestExcludeNativeBackedPVCs(t *testing.T) {
+	items := []velero.ResourceIdentifier{
+		{GroupResource: schema.GroupResource{Resource: "persistentvolumeclaims"}, Namespace: "ns", Name: "rootdisk-dv"},
+		{GroupResource: schema.GroupResource{Resource: "persistentvolumeclaims"}, Namespace: "ns", Name: "unrelated-pvc"},
+		{GroupResource: schema.GroupResource{Resource: "virtualmachineinstances"}, Namespace: "ns", Name: "my-vmi"},
+	}
+
+	nativeVolumes := []kvcore.Volume{
+		{
+			Name: "rootdisk",
+			VolumeSource: kvcore.VolumeSource{
+				DataVolume: &kvcore.DataVolumeSource{Name: "rootdisk-dv"},
+			},
+		},
+	}
+
+	filtered := ExcludeNativeBackedPVCs(items, nativeVolumes)
+	assert.Len(t, filtered, 2) // rootdisk-dv excluded, unrelated-pvc and VMI kept
+	assert.Equal(t, "unrelated-pvc", filtered[0].Name)
+	assert.Equal(t, "my-vmi", filtered[1].Name)
+}
+
+func TestIsCheckpointHealthy(t *testing.T) {
+	tests := []struct {
+		name     string
+		tracker  *unstructured.Unstructured
+		expected bool
+	}{
+		{
+			name: "healthy checkpoint",
+			tracker: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"latestCheckpoint": map[string]interface{}{
+							"name": "cp-1",
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "checkpoint redefinition required",
+			tracker: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{
+						"checkpointRedefinitionRequired": true,
+						"latestCheckpoint": map[string]interface{}{
+							"name": "cp-1",
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no checkpoint",
+			tracker: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"status": map[string]interface{}{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "no status",
+			tracker: &unstructured.Unstructured{
+				Object: map[string]interface{}{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsCheckpointHealthy(tt.tracker)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	// Test with nil backup
+	cfg := LoadConfig(nil)
+	assert.False(t, cfg.NativeBackupEnabled)
+	assert.False(t, cfg.IncrementalEnabled)
+	assert.Equal(t, "", cfg.DefaultScratchStorageClass)
+
+	// Test with backup labels overriding defaults
+	backup := &v1.Backup{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				NativeBackupLabel:   "true",
+				IncrementalLabel:    "true",
+				ScratchStorageLabel: "fast-ssd",
+				ConcurrencyLabel:    "3",
+				ForceFullEveryLabel: "5",
+			},
+		},
+	}
+	cfg = LoadConfig(backup)
+	assert.True(t, cfg.NativeBackupEnabled)
+	assert.True(t, cfg.IncrementalEnabled)
+	assert.Equal(t, "fast-ssd", cfg.DefaultScratchStorageClass)
+	assert.Equal(t, 3, cfg.MaxConcurrentBackups)
+	assert.Equal(t, 5, cfg.ForceFullEveryN)
+}
+
+func TestGetBackupMetadata(t *testing.T) {
+	vmBackup := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"status": map[string]interface{}{
+				"type":           "incremental",
+				"checkpointName": "cp-2",
+				"includedVolumes": []interface{}{
+					map[string]interface{}{
+						"volumeName": "rootdisk",
+						"diskTarget": "vda",
+					},
+					map[string]interface{}{
+						"volumeName": "datadisk",
+						"diskTarget": "vdb",
+					},
+				},
+			},
+		},
+	}
+
+	backupType, checkpoint, volumes := GetBackupMetadata(vmBackup)
+	assert.Equal(t, "incremental", backupType)
+	assert.Equal(t, "cp-2", checkpoint)
+	assert.Equal(t, "rootdisk,datadisk", volumes)
+}

--- a/pkg/util/nativebackup/progress.go
+++ b/pkg/util/nativebackup/progress.go
@@ -33,7 +33,10 @@ import (
 
 // CheckProgress checks the VirtualMachineBackup CR conditions and returns progress.
 func CheckProgress(operationID string, log logrus.FieldLogger) (velero.OperationProgress, error) {
-	ns, name := ParseOperationID(operationID)
+	ns, name, err := ParseOperationID(operationID)
+	if err != nil {
+		return velero.OperationProgress{}, err
+	}
 
 	vmBackup, err := GetVMBackup(ns, name)
 	if err != nil {
@@ -73,9 +76,13 @@ func CheckProgress(operationID string, log logrus.FieldLogger) (velero.Operation
 		if condType == "Failure" && condStatus == "True" {
 			message, _ := cond["message"].(string)
 			reason, _ := cond["reason"].(string)
+			errMsg := "native backup failed"
+			if message != "" || reason != "" {
+				errMsg = fmt.Sprintf("native backup failed: %s (%s)", message, reason)
+			}
 			return velero.OperationProgress{
 				Completed: true,
-				Err:       fmt.Sprintf("native backup failed: %s (%s)", message, reason),
+				Err:       errMsg,
 				Updated:   time.Now(),
 			}, nil
 		}
@@ -92,7 +99,10 @@ func CheckProgress(operationID string, log logrus.FieldLogger) (velero.Operation
 
 // CancelAndCleanup deletes the VirtualMachineBackup CR and its scratch PVCs
 func CancelAndCleanup(operationID string, log logrus.FieldLogger) error {
-	ns, name := ParseOperationID(operationID)
+	ns, name, err := ParseOperationID(operationID)
+	if err != nil {
+		return err
+	}
 
 	log.Infof("Cancelling native backup %s/%s", ns, name)
 

--- a/pkg/util/nativebackup/progress.go
+++ b/pkg/util/nativebackup/progress.go
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+)
+
+// CheckProgress checks the VirtualMachineBackup CR conditions and returns progress.
+func CheckProgress(operationID string, log logrus.FieldLogger) (velero.OperationProgress, error) {
+	ns, name := ParseOperationID(operationID)
+
+	vmBackup, err := GetVMBackup(ns, name)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			// CR was deleted (cancelled or cleaned up)
+			return velero.OperationProgress{
+				Completed: true,
+				Err:       "VirtualMachineBackup CR not found (may have been cancelled)",
+			}, nil
+		}
+		return velero.OperationProgress{}, fmt.Errorf("failed to get VirtualMachineBackup %s: %w", operationID, err)
+	}
+
+	conditions, found, _ := unstructured.NestedSlice(vmBackup.Object, "status", "conditions")
+	if !found {
+		// No conditions yet — still initializing
+		return velero.OperationProgress{
+			Completed:   false,
+			NTotal:      1,
+			Description: "Native backup initializing",
+			Updated:     time.Now(),
+		}, nil
+	}
+
+	for _, c := range conditions {
+		cond, ok := c.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+
+		if condType == "Ready" && condStatus == "True" {
+			return buildCompletedProgress(vmBackup, name, log), nil
+		}
+
+		if condType == "Failure" && condStatus == "True" {
+			message, _ := cond["message"].(string)
+			reason, _ := cond["reason"].(string)
+			return velero.OperationProgress{
+				Completed: true,
+				Err:       fmt.Sprintf("native backup failed: %s (%s)", message, reason),
+				Updated:   time.Now(),
+			}, nil
+		}
+	}
+
+	// Still in progress
+	return velero.OperationProgress{
+		Completed:   false,
+		NTotal:      1,
+		Description: "Native backup in progress",
+		Updated:     time.Now(),
+	}, nil
+}
+
+// CancelAndCleanup deletes the VirtualMachineBackup CR and its scratch PVCs
+func CancelAndCleanup(operationID string, log logrus.FieldLogger) error {
+	ns, name := ParseOperationID(operationID)
+
+	log.Infof("Cancelling native backup %s/%s", ns, name)
+
+	// Delete the VirtualMachineBackup CR (cancels in-progress backup)
+	if err := DeleteVMBackupCR(ns, name); err != nil && !k8serrors.IsNotFound(err) {
+		log.WithError(err).Warn("Failed to delete VirtualMachineBackup CR during cancel")
+	}
+
+	// Clean up scratch PVCs
+	if err := CleanupScratchPVCsByBackup(ns, name); err != nil {
+		log.WithError(err).Warn("Failed to clean up scratch PVCs during cancel")
+	}
+
+	return nil
+}
+
+// GetBackupMetadata extracts metadata from a completed VirtualMachineBackup for annotation
+func GetBackupMetadata(vmBackup *unstructured.Unstructured) (backupType, checkpoint, volumes string) {
+	backupType, _, _ = unstructured.NestedString(vmBackup.Object, "status", "type")
+	checkpoint, _, _ = unstructured.NestedString(vmBackup.Object, "status", "checkpointName")
+
+	includedVolumes, found, _ := unstructured.NestedSlice(vmBackup.Object, "status", "includedVolumes")
+	if found {
+		var volumeNames []string
+		for _, v := range includedVolumes {
+			vol, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			if name, ok := vol["volumeName"].(string); ok {
+				volumeNames = append(volumeNames, name)
+			}
+		}
+		volumes = strings.Join(volumeNames, ",")
+	}
+
+	return
+}
+
+func buildCompletedProgress(vmBackup *unstructured.Unstructured, name string, log logrus.FieldLogger) velero.OperationProgress {
+	backupType, checkpoint, volumes := GetBackupMetadata(vmBackup)
+
+	includedVolumes, _, _ := unstructured.NestedSlice(vmBackup.Object, "status", "includedVolumes")
+	volumeCount := int64(len(includedVolumes))
+	if volumeCount == 0 {
+		volumeCount = 1
+	}
+
+	log.Infof("Native backup %s completed: type=%s, checkpoint=%s, volumes=%s",
+		name, backupType, checkpoint, volumes)
+
+	return velero.OperationProgress{
+		Completed:      true,
+		NCompleted:     volumeCount,
+		NTotal:         volumeCount,
+		OperationUnits: "Volumes",
+		Description:    fmt.Sprintf("Native %s backup complete (%d volumes)", backupType, volumeCount),
+		Updated:        time.Now(),
+	}
+}

--- a/pkg/util/nativebackup/scratch.go
+++ b/pkg/util/nativebackup/scratch.go
@@ -1,0 +1,212 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	kvcore "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util"
+)
+
+// CreateScratchPVC creates a temporary PVC for the native backup to write to (Push mode).
+// The PVC is sized to the total capacity of the VM's persistent volumes and uses
+// the same storage class as the source (or an override from configuration).
+var CreateScratchPVC = func(vm *kvcore.VirtualMachine, backup *v1.Backup, log logrus.FieldLogger) (string, error) {
+	cfg := LoadConfig(backup)
+	ns := vm.Namespace
+	scratchName := ScratchPVCName(backup.Name, vm.Name)
+
+	// Calculate total capacity from VM volumes
+	totalCapacity, storageClassName := calculateVolumeCapacity(vm, ns, log)
+	if cfg.DefaultScratchStorageClass != "" {
+		storageClassName = cfg.DefaultScratchStorageClass
+	}
+
+	// Minimum 1Gi scratch PVC
+	minCapacity := resource.MustParse("1Gi")
+	if totalCapacity.Cmp(minCapacity) < 0 {
+		totalCapacity = minCapacity
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      scratchName,
+			Namespace: ns,
+			Labels: map[string]string{
+				NativeBackupPVCLabel:  "true",
+				ScratchPVCBackupLabel: BackupCRName(backup.Name, vm.Name),
+			},
+			Annotations: map[string]string{
+				ScratchPVCTTLAnnotation: time.Now().Add(24 * time.Hour).Format(time.RFC3339),
+				OriginalVolumeAnnotation: strings.Join(
+					GetVolumeClaimNames(FilterPersistentVolumes(vm.Spec.Template.Spec.Volumes)),
+					",",
+				),
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: totalCapacity,
+				},
+			},
+		},
+	}
+
+	if storageClassName != "" {
+		pvc.Spec.StorageClassName = &storageClassName
+	}
+
+	log.Infof("Creating scratch PVC %s/%s (capacity: %s, storageClass: %s)",
+		ns, scratchName, totalCapacity.String(), storageClassName)
+
+	client, err := util.GetK8sClient()
+	if err != nil {
+		return "", fmt.Errorf("failed to get k8s client for scratch PVC: %w", err)
+	}
+
+	_, err = client.CoreV1().PersistentVolumeClaims(ns).Create(
+		context.TODO(), pvc, metav1.CreateOptions{},
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed to create scratch PVC %s/%s: %w", ns, scratchName, err)
+	}
+
+	return scratchName, nil
+}
+
+// ScratchPVCName returns a deterministic name for the scratch PVC
+func ScratchPVCName(backupName, vmName string) string {
+	name := fmt.Sprintf("scratch-%s-%s", backupName, vmName)
+	// Kubernetes name limit is 253 chars
+	if len(name) > 253 {
+		name = name[:253]
+	}
+	return name
+}
+
+// CleanupScratchPVC deletes a specific scratch PVC
+var CleanupScratchPVC = func(name, ns string) error {
+	client, err := util.GetK8sClient()
+	if err != nil {
+		return err
+	}
+	return client.CoreV1().PersistentVolumeClaims(ns).Delete(
+		context.TODO(), name, metav1.DeleteOptions{},
+	)
+}
+
+// CleanupScratchPVCsByBackup deletes all scratch PVCs associated with a backup CR name
+var CleanupScratchPVCsByBackup = func(ns, backupCRName string) error {
+	client, err := util.GetK8sClient()
+	if err != nil {
+		return err
+	}
+	return client.CoreV1().PersistentVolumeClaims(ns).DeleteCollection(
+		context.TODO(),
+		metav1.DeleteOptions{},
+		metav1.ListOptions{LabelSelector: ScratchPVCBackupLabel + "=" + backupCRName},
+	)
+}
+
+// GarbageCollectStaleScratchPVCs deletes scratch PVCs that have exceeded their TTL
+func GarbageCollectStaleScratchPVCs(ns string, log logrus.FieldLogger) error {
+	client, err := util.GetK8sClient()
+	if err != nil {
+		return err
+	}
+
+	pvcs, err := client.CoreV1().PersistentVolumeClaims(ns).List(
+		context.TODO(),
+		metav1.ListOptions{LabelSelector: NativeBackupPVCLabel + "=true"},
+	)
+	if err != nil {
+		return err
+	}
+
+	for i := range pvcs.Items {
+		pvc := &pvcs.Items[i]
+		ttlStr, ok := pvc.Annotations[ScratchPVCTTLAnnotation]
+		if !ok {
+			continue
+		}
+		ttl, err := time.Parse(time.RFC3339, ttlStr)
+		if err != nil {
+			continue
+		}
+		if time.Now().After(ttl) {
+			log.Infof("Garbage collecting stale scratch PVC %s/%s (TTL expired)", ns, pvc.Name)
+			_ = client.CoreV1().PersistentVolumeClaims(ns).Delete(
+				context.TODO(), pvc.Name, metav1.DeleteOptions{},
+			)
+		}
+	}
+
+	return nil
+}
+
+// calculateVolumeCapacity computes the total capacity needed for the scratch PVC
+// by summing the sizes of all persistent volumes, and returns the storage class name
+// from the first PVC found.
+func calculateVolumeCapacity(vm *kvcore.VirtualMachine, ns string, log logrus.FieldLogger) (resource.Quantity, string) {
+	total := resource.Quantity{}
+	storageClassName := ""
+	persistentVolumes := FilterPersistentVolumes(vm.Spec.Template.Spec.Volumes)
+
+	for _, v := range persistentVolumes {
+		claimName := ""
+		if v.VolumeSource.PersistentVolumeClaim != nil {
+			claimName = v.VolumeSource.PersistentVolumeClaim.ClaimName
+		} else if v.VolumeSource.DataVolume != nil {
+			claimName = v.VolumeSource.DataVolume.Name
+		}
+
+		if claimName == "" {
+			continue
+		}
+
+		pvc, err := util.GetPVC(ns, claimName)
+		if err != nil {
+			log.WithError(err).Warnf("Failed to get PVC %s/%s for capacity calculation", ns, claimName)
+			continue
+		}
+
+		if capacity, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+			total.Add(capacity)
+		}
+
+		if storageClassName == "" && pvc.Spec.StorageClassName != nil {
+			storageClassName = *pvc.Spec.StorageClassName
+		}
+	}
+
+	return total, storageClassName
+}

--- a/pkg/util/nativebackup/scratch.go
+++ b/pkg/util/nativebackup/scratch.go
@@ -20,7 +20,6 @@
 package nativebackup
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -93,8 +92,10 @@ var CreateScratchPVC = func(vm *kvcore.VirtualMachine, backup *v1.Backup, log lo
 		return "", fmt.Errorf("failed to get k8s client for scratch PVC: %w", err)
 	}
 
+	ctx, cancel := apiContext()
+	defer cancel()
 	_, err = client.CoreV1().PersistentVolumeClaims(ns).Create(
-		context.TODO(), pvc, metav1.CreateOptions{},
+		ctx, pvc, metav1.CreateOptions{},
 	)
 	if err != nil {
 		return "", fmt.Errorf("failed to create scratch PVC %s/%s: %w", ns, scratchName, err)
@@ -119,8 +120,10 @@ var CleanupScratchPVC = func(name, ns string) error {
 	if err != nil {
 		return err
 	}
+	ctx, cancel := apiContext()
+	defer cancel()
 	return client.CoreV1().PersistentVolumeClaims(ns).Delete(
-		context.TODO(), name, metav1.DeleteOptions{},
+		ctx, name, metav1.DeleteOptions{},
 	)
 }
 
@@ -130,8 +133,10 @@ var CleanupScratchPVCsByBackup = func(ns, backupCRName string) error {
 	if err != nil {
 		return err
 	}
+	ctx, cancel := apiContext()
+	defer cancel()
 	return client.CoreV1().PersistentVolumeClaims(ns).DeleteCollection(
-		context.TODO(),
+		ctx,
 		metav1.DeleteOptions{},
 		metav1.ListOptions{LabelSelector: ScratchPVCBackupLabel + "=" + backupCRName},
 	)
@@ -144,8 +149,10 @@ func GarbageCollectStaleScratchPVCs(ns string, log logrus.FieldLogger) error {
 		return err
 	}
 
+	ctx, cancel := apiContext()
+	defer cancel()
 	pvcs, err := client.CoreV1().PersistentVolumeClaims(ns).List(
-		context.TODO(),
+		ctx,
 		metav1.ListOptions{LabelSelector: NativeBackupPVCLabel + "=true"},
 	)
 	if err != nil {
@@ -160,13 +167,18 @@ func GarbageCollectStaleScratchPVCs(ns string, log logrus.FieldLogger) error {
 		}
 		ttl, err := time.Parse(time.RFC3339, ttlStr)
 		if err != nil {
+			log.Warnf("Invalid TTL annotation on scratch PVC %s/%s: %v", ns, pvc.Name, err)
 			continue
 		}
 		if time.Now().After(ttl) {
 			log.Infof("Garbage collecting stale scratch PVC %s/%s (TTL expired)", ns, pvc.Name)
-			_ = client.CoreV1().PersistentVolumeClaims(ns).Delete(
-				context.TODO(), pvc.Name, metav1.DeleteOptions{},
-			)
+			delCtx, delCancel := apiContext()
+			if delErr := client.CoreV1().PersistentVolumeClaims(ns).Delete(
+				delCtx, pvc.Name, metav1.DeleteOptions{},
+			); delErr != nil {
+				log.WithError(delErr).Warnf("Failed to garbage collect scratch PVC %s/%s", ns, pvc.Name)
+			}
+			delCancel()
 		}
 	}
 

--- a/pkg/util/nativebackup/tracker.go
+++ b/pkg/util/nativebackup/tracker.go
@@ -20,8 +20,8 @@
 package nativebackup
 
 import (
-	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -59,8 +59,10 @@ var EnsureTracker = func(vmName, ns string) (*unstructured.Unstructured, error) 
 	}
 
 	// Try to get existing tracker
+	ctx, cancel := apiContext()
+	defer cancel()
 	existing, err := client.Resource(vmBackupTrackerGVR).Namespace(ns).Get(
-		context.TODO(), trackerName, metav1.GetOptions{},
+		ctx, trackerName, metav1.GetOptions{},
 	)
 	if err == nil {
 		return existing, nil
@@ -77,6 +79,9 @@ var EnsureTracker = func(vmName, ns string) (*unstructured.Unstructured, error) 
 			"metadata": map[string]interface{}{
 				"name":      trackerName,
 				"namespace": ns,
+				"annotations": map[string]interface{}{
+					IncrementalCountAnnotation: "0",
+				},
 			},
 			"spec": map[string]interface{}{
 				"source": map[string]interface{}{
@@ -88,14 +93,18 @@ var EnsureTracker = func(vmName, ns string) (*unstructured.Unstructured, error) 
 		},
 	}
 
+	createCtx, createCancel := apiContext()
+	defer createCancel()
 	created, err := client.Resource(vmBackupTrackerGVR).Namespace(ns).Create(
-		context.TODO(), obj, metav1.CreateOptions{},
+		createCtx, obj, metav1.CreateOptions{},
 	)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
 			// Race condition: another backup created it
+			getCtx, getCancel := apiContext()
+			defer getCancel()
 			return client.Resource(vmBackupTrackerGVR).Namespace(ns).Get(
-				context.TODO(), trackerName, metav1.GetOptions{},
+				getCtx, trackerName, metav1.GetOptions{},
 			)
 		}
 		return nil, fmt.Errorf("failed to create tracker %s/%s: %w", ns, trackerName, err)
@@ -109,6 +118,10 @@ var EnsureTracker = func(vmName, ns string) (*unstructured.Unstructured, error) 
 // - checkpointRedefinitionRequired is true (VM restarted, libvirt checkpoint invalid)
 // - no latestCheckpoint exists (first backup, or checkpoint cleared)
 func IsCheckpointHealthy(tracker *unstructured.Unstructured) bool {
+	if tracker == nil {
+		return false
+	}
+
 	// Check checkpointRedefinitionRequired flag
 	required, found, _ := unstructured.NestedBool(
 		tracker.Object, "status", "checkpointRedefinitionRequired",
@@ -150,6 +163,8 @@ func ResolveSource(
 	if !IsCheckpointHealthy(tracker) {
 		log.Infof("Tracker checkpoint unhealthy for VM %s/%s (VM may have restarted), forcing full backup",
 			vm.Namespace, vm.Name)
+		// Reset counter on full backup
+		updateIncrementalCount(tracker, 0, vm.Namespace, log)
 		return SourceRef{
 			APIGroup: "kubevirt.io",
 			Kind:     "VirtualMachine",
@@ -163,6 +178,8 @@ func ResolveSource(
 		if count >= cfg.ForceFullEveryN {
 			log.Infof("Forcing full backup for VM %s/%s after %d incrementals",
 				vm.Namespace, vm.Name, count)
+			// Reset counter on full backup
+			updateIncrementalCount(tracker, 0, vm.Namespace, log)
 			return SourceRef{
 				APIGroup: "kubevirt.io",
 				Kind:     "VirtualMachine",
@@ -171,8 +188,11 @@ func ResolveSource(
 		}
 	}
 
-	// Incremental via tracker
-	log.Infof("Using incremental backup via tracker for VM %s/%s", vm.Namespace, vm.Name)
+	// Incremental via tracker — increment counter
+	count := getIncrementalCount(tracker)
+	updateIncrementalCount(tracker, count+1, vm.Namespace, log)
+
+	log.Infof("Using incremental backup via tracker for VM %s/%s (incremental #%d)", vm.Namespace, vm.Name, count+1)
 	return SourceRef{
 		APIGroup: "backup.kubevirt.io",
 		Kind:     "VirtualMachineBackupTracker",
@@ -180,17 +200,47 @@ func ResolveSource(
 	}, false, nil
 }
 
-// getIncrementalCount returns the number of incremental backups since the last full.
-// This is approximated by checking the latestCheckpoint's creation time vs tracker creation.
+// getIncrementalCount reads the incremental backup counter from the tracker annotation.
 func getIncrementalCount(tracker *unstructured.Unstructured) int {
-	// Check if latestCheckpoint has volumes (indicates at least one successful backup)
-	volumes, found, _ := unstructured.NestedSlice(
-		tracker.Object, "status", "latestCheckpoint", "volumes",
-	)
-	if !found || len(volumes) == 0 {
+	annotations, _, _ := unstructured.NestedStringMap(tracker.Object, "metadata", "annotations")
+	if annotations == nil {
 		return 0
 	}
-	// For now, we count the presence of a checkpoint as 1 incremental.
-	// A more sophisticated approach would track count in an annotation.
-	return 1
+	countStr, ok := annotations[IncrementalCountAnnotation]
+	if !ok {
+		return 0
+	}
+	n, err := strconv.Atoi(countStr)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// updateIncrementalCount writes the incremental counter annotation on the tracker CR.
+func updateIncrementalCount(tracker *unstructured.Unstructured, count int, ns string, log logrus.FieldLogger) {
+	annotations, _, _ := unstructured.NestedStringMap(tracker.Object, "metadata", "annotations")
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[IncrementalCountAnnotation] = strconv.Itoa(count)
+
+	// Update in-memory object
+	_ = unstructured.SetNestedStringMap(tracker.Object, annotations, "metadata", "annotations")
+
+	// Persist to cluster
+	client, err := getDynamicClient()
+	if err != nil {
+		log.WithError(err).Warn("Failed to get dynamic client for tracker annotation update")
+		return
+	}
+
+	ctx, cancel := apiContext()
+	defer cancel()
+	_, err = client.Resource(vmBackupTrackerGVR).Namespace(ns).Update(
+		ctx, tracker, metav1.UpdateOptions{},
+	)
+	if err != nil {
+		log.WithError(err).Warnf("Failed to update incremental count annotation on tracker (count=%d)", count)
+	}
 }

--- a/pkg/util/nativebackup/tracker.go
+++ b/pkg/util/nativebackup/tracker.go
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	kvcore "kubevirt.io/api/core/v1"
+)
+
+var vmBackupTrackerGVR = schema.GroupVersionResource{
+	Group:    "backup.kubevirt.io",
+	Version:  "v1alpha1",
+	Resource: "virtualmachinebackuptrackers",
+}
+
+// TrackerName returns a deterministic name for a backup tracker
+func TrackerName(vmName string) string {
+	name := fmt.Sprintf("%s-backup-tracker", vmName)
+	if len(name) > 253 {
+		name = name[:253]
+	}
+	return name
+}
+
+// EnsureTracker creates a VirtualMachineBackupTracker if it doesn't exist,
+// or returns the existing one. Trackers are created once per VM and persist
+// across backups to maintain checkpoint state for incremental backups.
+var EnsureTracker = func(vmName, ns string) (*unstructured.Unstructured, error) {
+	trackerName := TrackerName(vmName)
+	client, err := getDynamicClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get dynamic client for tracker: %w", err)
+	}
+
+	// Try to get existing tracker
+	existing, err := client.Resource(vmBackupTrackerGVR).Namespace(ns).Get(
+		context.TODO(), trackerName, metav1.GetOptions{},
+	)
+	if err == nil {
+		return existing, nil
+	}
+	if !k8serrors.IsNotFound(err) {
+		return nil, fmt.Errorf("failed to check tracker %s/%s: %w", ns, trackerName, err)
+	}
+
+	// Create new tracker
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "backup.kubevirt.io/v1alpha1",
+			"kind":       "VirtualMachineBackupTracker",
+			"metadata": map[string]interface{}{
+				"name":      trackerName,
+				"namespace": ns,
+			},
+			"spec": map[string]interface{}{
+				"source": map[string]interface{}{
+					"apiGroup": "kubevirt.io",
+					"kind":     "VirtualMachine",
+					"name":     vmName,
+				},
+			},
+		},
+	}
+
+	created, err := client.Resource(vmBackupTrackerGVR).Namespace(ns).Create(
+		context.TODO(), obj, metav1.CreateOptions{},
+	)
+	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			// Race condition: another backup created it
+			return client.Resource(vmBackupTrackerGVR).Namespace(ns).Get(
+				context.TODO(), trackerName, metav1.GetOptions{},
+			)
+		}
+		return nil, fmt.Errorf("failed to create tracker %s/%s: %w", ns, trackerName, err)
+	}
+
+	return created, nil
+}
+
+// IsCheckpointHealthy checks if the tracker's checkpoint is valid for incremental backup.
+// Returns false if:
+// - checkpointRedefinitionRequired is true (VM restarted, libvirt checkpoint invalid)
+// - no latestCheckpoint exists (first backup, or checkpoint cleared)
+func IsCheckpointHealthy(tracker *unstructured.Unstructured) bool {
+	// Check checkpointRedefinitionRequired flag
+	required, found, _ := unstructured.NestedBool(
+		tracker.Object, "status", "checkpointRedefinitionRequired",
+	)
+	if found && required {
+		return false
+	}
+
+	// Check latestCheckpoint exists
+	checkpoint, found, _ := unstructured.NestedMap(tracker.Object, "status", "latestCheckpoint")
+	return found && checkpoint != nil
+}
+
+// ResolveSource determines the backup source (VM for full, Tracker for incremental)
+// and whether a full backup should be forced.
+func ResolveSource(
+	vm *kvcore.VirtualMachine,
+	backup *v1.Backup,
+	log logrus.FieldLogger,
+) (source SourceRef, forceFullBackup bool, err error) {
+	cfg := LoadConfig(backup)
+
+	// If incremental is not enabled, always do full backup via VM source
+	if !cfg.IncrementalEnabled {
+		return SourceRef{
+			APIGroup: "kubevirt.io",
+			Kind:     "VirtualMachine",
+			Name:     vm.Name,
+		}, false, nil
+	}
+
+	// Ensure tracker exists
+	tracker, err := EnsureTracker(vm.Name, vm.Namespace)
+	if err != nil {
+		return SourceRef{}, false, err
+	}
+
+	// Check if checkpoint needs redefinition (VM restarted)
+	if !IsCheckpointHealthy(tracker) {
+		log.Infof("Tracker checkpoint unhealthy for VM %s/%s (VM may have restarted), forcing full backup",
+			vm.Namespace, vm.Name)
+		return SourceRef{
+			APIGroup: "kubevirt.io",
+			Kind:     "VirtualMachine",
+			Name:     vm.Name,
+		}, true, nil
+	}
+
+	// Check forceFullEveryN
+	if cfg.ForceFullEveryN > 0 {
+		count := getIncrementalCount(tracker)
+		if count >= cfg.ForceFullEveryN {
+			log.Infof("Forcing full backup for VM %s/%s after %d incrementals",
+				vm.Namespace, vm.Name, count)
+			return SourceRef{
+				APIGroup: "kubevirt.io",
+				Kind:     "VirtualMachine",
+				Name:     vm.Name,
+			}, true, nil
+		}
+	}
+
+	// Incremental via tracker
+	log.Infof("Using incremental backup via tracker for VM %s/%s", vm.Namespace, vm.Name)
+	return SourceRef{
+		APIGroup: "backup.kubevirt.io",
+		Kind:     "VirtualMachineBackupTracker",
+		Name:     TrackerName(vm.Name),
+	}, false, nil
+}
+
+// getIncrementalCount returns the number of incremental backups since the last full.
+// This is approximated by checking the latestCheckpoint's creation time vs tracker creation.
+func getIncrementalCount(tracker *unstructured.Unstructured) int {
+	// Check if latestCheckpoint has volumes (indicates at least one successful backup)
+	volumes, found, _ := unstructured.NestedSlice(
+		tracker.Object, "status", "latestCheckpoint", "volumes",
+	)
+	if !found || len(volumes) == 0 {
+		return 0
+	}
+	// For now, we count the presence of a checkpoint as 1 incremental.
+	// A more sophisticated approach would track count in an annotation.
+	return 1
+}

--- a/pkg/util/nativebackup/volumes.go
+++ b/pkg/util/nativebackup/volumes.go
@@ -1,0 +1,82 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Velero Plugin Authors.
+ *
+ */
+
+package nativebackup
+
+import (
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	kvcore "kubevirt.io/api/core/v1"
+)
+
+// FilterPersistentVolumes returns only volumes that need native backup.
+// Skips ephemeral volumes: ConfigMap, Secret, CloudInit, ServiceAccount, DownwardAPI, Sysprep.
+func FilterPersistentVolumes(volumes []kvcore.Volume) []kvcore.Volume {
+	var persistent []kvcore.Volume
+	for _, v := range volumes {
+		if v.VolumeSource.DataVolume != nil ||
+			v.VolumeSource.PersistentVolumeClaim != nil ||
+			v.VolumeSource.MemoryDump != nil {
+			persistent = append(persistent, v)
+		}
+		// ContainerDisk is ephemeral (backed by container image), skip it
+		// ConfigMap, Secret, CloudInitNoCloud, CloudInitConfigDrive,
+		// ServiceAccount, DownwardMetrics, Sysprep are all ephemeral
+	}
+	return persistent
+}
+
+// GetVolumeClaimNames extracts PVC/DV claim names from a list of volumes
+func GetVolumeClaimNames(volumes []kvcore.Volume) []string {
+	var names []string
+	for _, v := range volumes {
+		if v.VolumeSource.PersistentVolumeClaim != nil {
+			names = append(names, v.VolumeSource.PersistentVolumeClaim.ClaimName)
+		}
+		if v.VolumeSource.DataVolume != nil {
+			names = append(names, v.VolumeSource.DataVolume.Name)
+		}
+	}
+	return names
+}
+
+// ExcludeNativeBackedPVCs removes PVC ResourceIdentifiers that are handled by native backup,
+// preventing CSI double-snapshots of the same volumes.
+func ExcludeNativeBackedPVCs(
+	items []velero.ResourceIdentifier,
+	nativeVolumes []kvcore.Volume,
+) []velero.ResourceIdentifier {
+	nativeNames := make(map[string]bool)
+	for _, v := range nativeVolumes {
+		if v.VolumeSource.PersistentVolumeClaim != nil {
+			nativeNames[v.VolumeSource.PersistentVolumeClaim.ClaimName] = true
+		}
+		if v.VolumeSource.DataVolume != nil {
+			nativeNames[v.VolumeSource.DataVolume.Name] = true
+		}
+	}
+
+	var filtered []velero.ResourceIdentifier
+	for _, item := range items {
+		if item.Resource == "persistentvolumeclaims" && nativeNames[item.Name] {
+			continue // Handled by native backup
+		}
+		filtered = append(filtered, item)
+	}
+	return filtered
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds optional support for the native KubeVirt backup API (`backup.kubevirt.io/v1alpha1`) alongside the existing CSI snapshot path. When enabled via Velero Backup labels, the plugin uses `VirtualMachineBackup` CRs for CBT-based, QEMU-aware backup with incremental support via `VirtualMachineBackupTracker` checkpoints.

Key capabilities:
- **Async native backup** via Velero BackupItemAction v2 (`Execute` → `Progress` → `Cancel`)
- **Incremental backup** via tracker checkpoints with configurable `forceFullEveryN`
- **Guest agent auto-detection** — skips quiesce when QEMU agent is not connected
- **Scratch PVC pattern** — native backup writes to a temporary PVC, Velero snapshots it, preventing CSI double-snapshot on source PVCs
- **Graceful CSI fallback** — falls back to existing CSI path if CRDs not installed, VM not running, or any native operation fails
- **Cleanup on delete** — `DeleteItemAction` removes `VirtualMachineBackup` CRs and scratch PVCs when Velero backup is deleted
- **Atomic grouping** — `ItemBlockAction` ensures VM + related resources are backed up together

All behavior is opt-in via labels; existing CSI-only workflows are unaffected.

**Which issue(s) this PR fixes**:

Fixes #411

**Special notes for your reviewer**:

The implementation spans three commits for reviewability:

1. **`feat: integrate native KubeVirt backup API`** — Core implementation: new `pkg/util/nativebackup/` package (8 files), v2 upgrades to VM backup/restore actions, new `DeleteItemAction` and `ItemBlockAction`, RBAC, unit tests
2. **`fix: annotation loss, nil panic, and silent cleanup errors`** — Bug fixes found during review: annotations set on VM struct instead of unstructured item, nil guard in `volumeInDVTemplates`, cleanup error logging
3. **`improve: API timeouts, incremental counter, error propagation, agent check`** — Hardening: 30s context timeout on all K8s API calls, annotation-based incremental counter (replaces stub), `ParseOperationID` returns error, guest agent check returns error for caller differentiation

Configuration is via labels on the Velero Backup object:

| Label | Purpose |
|-------|---------|
| `velero.kubevirt.io/native-backup` | Enable native backup for this Backup |
| `velero.kubevirt.io/incremental-backup` | Enable incremental via tracker |
| `velero.kubevirt.io/skip-quiesce` | Force skip filesystem quiesce |
| `velero.kubevirt.io/scratch-storage-class` | Override scratch PVC storage class |
| `velero.kubevirt.io/force-full-every-n` | Force full backup every N incrementals |
| `velero.kubevirt.io/native-backup-concurrency` | Max concurrent native backups |

Cluster-wide defaults via ConfigMap `kubevirt-velero-plugin-config` in the `velero` namespace.

Verified against KubeVirt v1.8.1 `VirtualMachineBackup` and `VirtualMachineBackupTracker` CRD schemas from a live cluster.

**Release note**:

```release-note
Add optional native KubeVirt backup API integration (backup.kubevirt.io/v1alpha1) for CBT-based incremental backup with QEMU guest agent quiesce support. Enable via `velero.kubevirt.io/native-backup` label on Velero Backup objects. Falls back to CSI snapshots when native API is unavailable or fails.
```