### PR TITLE
NetworkAttachmentDefinition plugin to handle namespace mapping

### DIFF
--- a/hack/velero/add-plugin.sh
+++ b/hack/velero/add-plugin.sh
@@ -33,7 +33,7 @@ function wait_plugin_available {
                     plugin get | grep kubevirt-velero | wc -l)
 
     wait_time=0
-    expected_actions="20"
+    expected_actions="22"
     while [[ $available != $expected_actions ]] && [[ $wait_time -lt 60 ]]; do
       wait_time=$((wait_time + 5))
       sleep 5

--- a/main.go
+++ b/main.go
@@ -36,6 +36,7 @@ func main() {
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pvc-action", newPVCRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-pod-action", newPodRestoreItemAction).
 		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-volumesnapshot-action", newVolumeSnapshotRestoreItemAction).
+		RegisterRestoreItemAction("kubevirt-velero-plugin/restore-networkattachmentdefinition-action", newNADRestoreItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-datavolume-action", newDVBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-pvc-action", newPVCBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-volumesnapshot-action", newVolumeSnapshotBackupItemAction).
@@ -99,3 +100,7 @@ func newVolumeSnapshotRestoreItemAction(logger logrus.FieldLogger) (interface{},
 	return plugin.NewVolumeSnapshotRestoreItemAction(logger), nil
 }
 
+func newNADRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating NADRestoreItemAction")
+	return plugin.NewNADRestoreItemAction(logger), nil
+}

--- a/pkg/plugin/nad_restore_item_action.go
+++ b/pkg/plugin/nad_restore_item_action.go
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	netv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NADRestoreItemAction is a restore item action for NetworkAttachmentDefinitions
+type NADRestoreItemAction struct {
+	log logrus.FieldLogger
+}
+
+// NewNADRestoreItemAction instantiates a NADRestoreItemAction.
+func NewNADRestoreItemAction(log logrus.FieldLogger) *NADRestoreItemAction {
+	return &NADRestoreItemAction{log: log}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *NADRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{
+			"NetworkAttachmentDefinition",
+		},
+	}, nil
+}
+
+// Execute performs the restore action for a NetworkAttachmentDefinition.
+func (p *NADRestoreItemAction) Execute(input *velero.RestoreItemActionExecuteInput) (*velero.RestoreItemActionExecuteOutput, error) {
+	p.log.Info("Executing NADRestoreItemAction")
+
+	if input == nil {
+		return nil, fmt.Errorf("input object nil!")
+	}
+
+	var nad netv1.NetworkAttachmentDefinition
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(input.Item.UnstructuredContent(), &nad); err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	p.log.Infof("handling NetworkAttachmentDefinition %v/%v", nad.GetNamespace(), nad.GetName())
+
+	if nad.Spec.Config != "" {
+		var config map[string]interface{}
+		if err := json.Unmarshal([]byte(nad.Spec.Config), &config); err != nil {
+			return nil, errors.Wrap(err, "failed to unmarshal NAD config JSON")
+		}
+
+		if val, ok := config["netAttachDefName"]; ok {
+			if netAttachDefName, isString := val.(string); isString && netAttachDefName != "" {
+				parts := strings.Split(netAttachDefName, "/")
+				
+				// If it's in the format "namespace/name"
+				if len(parts) == 2 {
+					ns := parts[0]
+					name := parts[1]
+					
+					// Check if the namespace is in the Velero restore namespace mapping
+					if mappedNs, mapped := input.Restore.Spec.NamespaceMapping[ns]; mapped {
+						p.log.Infof("Mapping netAttachDefName namespace from %s to %s", ns, mappedNs)
+						config["netAttachDefName"] = fmt.Sprintf("%s/%s", mappedNs, name)
+						
+						// Marshal the modified config back to JSON
+						newConfigBytes, err := json.Marshal(config)
+						if err != nil {
+							return nil, errors.Wrap(err, "failed to marshal updated NAD config JSON")
+						}
+						nad.Spec.Config = string(newConfigBytes)
+
+						// Convert back to unstructured since we modified the object
+						item, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&nad)
+						if err != nil {
+							return nil, errors.WithStack(err)
+						}
+						
+						return velero.NewRestoreItemActionExecuteOutput(&unstructured.Unstructured{Object: item}), nil
+					}
+				}
+			}
+		}
+	}
+
+	return velero.NewRestoreItemActionExecuteOutput(input.Item), nil
+}

--- a/pkg/plugin/nad_restore_item_action.go
+++ b/pkg/plugin/nad_restore_item_action.go
@@ -46,7 +46,7 @@ func NewNADRestoreItemAction(log logrus.FieldLogger) *NADRestoreItemAction {
 func (p *NADRestoreItemAction) AppliesTo() (velero.ResourceSelector, error) {
 	return velero.ResourceSelector{
 		IncludedResources: []string{
-			"NetworkAttachmentDefinition",
+			"network-attachment-definition",
 		},
 	}, nil
 }

--- a/tests/framework/backup.go
+++ b/tests/framework/backup.go
@@ -283,7 +283,7 @@ func CreateRestoreWithClearedMACAddress(ctx context.Context, backupName, restore
 	return CreateRestoreWithLabels(ctx, backupName, restoreName, backupNamespace, wait, map[string]string{"velero.kubevirt.io/clear-mac-address": "true"})
 }
 
-func CreateRestoreWithNamespaceMapping(ctx context.Context, backupName, restoreName, backupNamespace string, namespaceMappings map[string]string, wait bool) error {
+func CreateRestoreWithNamespaceMapping(ctx context.Context, backupName, restoreName, backupNamespace string, namespaceMappings map[string]string, labels map[string]string, wait bool) error {
 	args := []string{
 		"restore", "create", restoreName,
 		"--from-backup", backupName,
@@ -296,6 +296,14 @@ func CreateRestoreWithNamespaceMapping(ctx context.Context, backupName, restoreN
 			pairs = append(pairs, fmt.Sprintf("%s:%s", src, dst))
 		}
 		args = append(args, "--namespace-mappings", strings.Join(pairs, ","))
+	}
+
+	if len(labels) > 0 {
+		labelPairs := []string{}
+		for key, value := range labels {
+			labelPairs = append(labelPairs, fmt.Sprintf("%s=%s", key, value))
+		}
+		args = append(args, "--labels", strings.Join(labelPairs, ","))
 	}
 
 	restoreCmd := exec.CommandContext(ctx, veleroCLI, args...)

--- a/tests/framework/backup.go
+++ b/tests/framework/backup.go
@@ -283,6 +283,37 @@ func CreateRestoreWithClearedMACAddress(ctx context.Context, backupName, restore
 	return CreateRestoreWithLabels(ctx, backupName, restoreName, backupNamespace, wait, map[string]string{"velero.kubevirt.io/clear-mac-address": "true"})
 }
 
+func CreateRestoreWithNamespaceMapping(ctx context.Context, backupName, restoreName, backupNamespace string, namespaceMappings map[string]string, wait bool) error {
+	args := []string{
+		"restore", "create", restoreName,
+		"--from-backup", backupName,
+		"--namespace", backupNamespace,
+	}
+
+	if len(namespaceMappings) > 0 {
+		pairs := []string{}
+		for src, dst := range namespaceMappings {
+			pairs = append(pairs, fmt.Sprintf("%s:%s", src, dst))
+		}
+		args = append(args, "--namespace-mappings", strings.Join(pairs, ","))
+	}
+
+	restoreCmd := exec.CommandContext(ctx, veleroCLI, args...)
+	restoreCmd.Stdout = os.Stdout
+	restoreCmd.Stderr = os.Stderr
+	ginkgo.By(fmt.Sprintf("restore cmd =%v\n", restoreCmd))
+	err := restoreCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	if wait {
+		return waitForRestoreTerminalPhase(ctx, restoreName, backupNamespace)
+	}
+
+	return nil
+}
+
 func GetRestore(ctx context.Context, restoreName string, backupNamespace string) (*v1.Restore, error) {
 	checkCMD := exec.CommandContext(ctx, veleroCLI, "restore", "get", "-n", backupNamespace, "-o", "json", restoreName)
 

--- a/tests/framework/kubectl.go
+++ b/tests/framework/kubectl.go
@@ -51,6 +51,23 @@ func (f *Framework) RunKubectlCreateYamlCommand(yamlPath string) error {
 	return err
 }
 
+// RunKubectlCreateYamlCommandWithNamespace substitutes {{KVP_NAMESPACE}} with the test namespace, then kubectl create.
+func (f *Framework) RunKubectlCreateYamlCommandWithNamespace(yamlPath string) error {
+	kubeconfig := f.KubeConfig
+	path := f.KubectlPath
+	cmdString := fmt.Sprintf(
+		"cat %s | sed 's|{{KVP_NAMESPACE}}|%s|g' | %s create -n %s -f -",
+		yamlPath, f.Namespace.Name, path, f.Namespace.Name,
+	)
+	cmd := exec.Command("bash", "-c", cmdString)
+	kubeconfEnv := fmt.Sprintf("KUBECONFIG=%s", kubeconfig)
+	cmd.Env = append(os.Environ(), kubeconfEnv)
+	outBytes, err := cmd.CombinedOutput()
+	fmt.Fprintf(GinkgoWriter, "INFO: Output from kubectl: %s\n", string(outBytes))
+
+	return err
+}
+
 // KubectlDescribeVeleroBackup execs to the velero pod and runs a describe command on the given
 // backup name including details of the resources that were backed up
 func (f *Framework) KubectlDescribeVeleroBackup(ctx context.Context, podName, backupName string) (map[string]interface{}, error) {

--- a/tests/framework/manifests_utils.go
+++ b/tests/framework/manifests_utils.go
@@ -92,6 +92,14 @@ func (f *Framework) CreateNetworkAttachmentDefinition() error {
 	return f.RunKubectlCommand("create", "-f", "manifests/network-attachment-definition.yaml", "-n", f.Namespace.Name)
 }
 
+func (f *Framework) CreateNetworkAttachmentDefinitionOvn() error {
+	return f.RunKubectlCreateYamlCommandWithNamespace("manifests/network-attachment-definition-ovn.yaml")
+}
+
 func (f *Framework) CreateVMWithNAD() error {
 	return f.RunKubectlCreateYamlCommand("manifests/vm_with_nad.yaml")
+}
+
+func (f *Framework) CreateVMWithNADOvn() error {
+	return f.RunKubectlCreateYamlCommand("manifests/vm_with_nad_ovn.yaml")
 }

--- a/tests/manifests/network-attachment-definition-ovn.yaml
+++ b/tests/manifests/network-attachment-definition-ovn.yaml
@@ -1,0 +1,13 @@
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: nad-1
+spec:
+  config: |-
+    {
+        "cniVersion": "0.3.1",
+        "name": "nad-1",
+        "type": "ovn-k8s-cni-overlay",
+        "netAttachDefName": "{{KVP_NAMESPACE}}/nad-1",
+        "topology": "layer2"
+    }

--- a/tests/manifests/vm_with_nad_ovn.yaml
+++ b/tests/manifests/vm_with_nad_ovn.yaml
@@ -1,0 +1,77 @@
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: test-vm-with-nad-ovn
+  labels:
+    a.test.label: included
+spec:
+  dataVolumeTemplates:
+  - metadata:
+      name: test-dv
+    spec:
+      pvc:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi
+        storageClassName: {{KVP_STORAGE_CLASS}}
+      source:
+        registry:
+          pullMethod: node
+          url: docker://quay.io/kubevirt/alpine-with-test-tooling-container-disk:v0.57.1
+  runStrategy: Always
+  template:
+    metadata:
+      creationTimestamp: null
+      name: test-vm-with-nad-ovn
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: volume0
+          - disk:
+              bus: virtio
+            name: volume1
+          interfaces:
+          - masquerade: {}
+            name: default
+          - bridge: {}
+            name: secondary
+          rng: {}
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 256Mi
+      networks:
+      - name: default
+        pod: {}
+      - name: secondary
+        multus:
+          networkName: nad-1
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - dataVolume:
+          name: test-dv
+        name: volume0
+      - cloudInitNoCloud:
+          networkData: |-
+            ethernets:
+              eth0:
+                addresses:
+                - fd10:0:2::2/120
+                dhcp4: true
+                gateway6: fd10:0:2::1
+                match: {}
+                nameservers:
+                  addresses:
+                  - 10.96.0.10
+                  search:
+                  - default.svc.cluster.local
+                  - svc.cluster.local
+                  - cluster.local
+            version: 2
+        name: volume1

--- a/tests/vm_backup_test.go
+++ b/tests/vm_backup_test.go
@@ -809,8 +809,9 @@ var _ = Describe("[smoke] VM Backup", func() {
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusRunning)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Dumping VM YAML before backup")
+			By("Dumping VM and NAD YAML before backup")
 			dumpVMYaml(f.KvClient, f.Namespace.Name, vm.Name)
+			dumpNADYaml(f, nadName, f.Namespace.Name)
 
 			By("Creating backup with label selector (only VM is labeled, NAD must be discovered by plugin)")
 			err = f.RunBackupScript(timeout, backupName, "", "a.test.label=included", f.Namespace.Name, snapshotLocation, f.BackupNamespace)
@@ -822,21 +823,25 @@ var _ = Describe("[smoke] VM Backup", func() {
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Creating restore with namespace mapping")
+			By("Creating restore with namespace mapping and clear MAC address")
 			err = framework.CreateRestoreWithNamespaceMapping(timeout, backupName, restoreName, f.BackupNamespace,
-				map[string]string{f.Namespace.Name: targetNs.Name}, true)
+				map[string]string{f.Namespace.Name: targetNs.Name},
+				map[string]string{"velero.kubevirt.io/clear-mac-address": "true"},
+				true)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying VM")
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, targetNs.Name, vm.Name, kvv1.VirtualMachineStatusStopped, kvv1.VirtualMachineStatusRunning)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Dumping VM YAML after restore")
+			By("Dumping VM and NAD YAML after restore")
 			dumpVMYaml(f.KvClient, targetNs.Name, vm.Name)
+			dumpNADYaml(f, nadName, targetNs.Name)
 
 			By("Verifying NetworkAttachmentDefinition was restored")
 			nadRestored, err := getNetworkAttachmentDefinition(f, nadName, targetNs.Name)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "INFO: NAD %q in namespace %q: %s\n", nadName, targetNs.Name, nadRestored)
 			Expect(nadRestored).ToNot(BeEmpty(), "NAD should have been restored")
 
 			By("Verifying VM still references the NAD in its spec")
@@ -844,6 +849,7 @@ var _ = Describe("[smoke] VM Backup", func() {
 			Expect(err).ToNot(HaveOccurred())
 			foundNAD := false
 			for _, net := range restoredVM.Spec.Template.Spec.Networks {
+				fmt.Fprintf(GinkgoWriter, "INFO: VM network entry: Name=%s, Multus=%v\n", net.Name, net.Multus)
 				if net.Multus != nil && net.Multus.NetworkName == nadName {
 					foundNAD = true
 					break
@@ -854,6 +860,7 @@ var _ = Describe("[smoke] VM Backup", func() {
 			By("Verifying original VM still exists in source namespace")
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "INFO: Original VM %q in source namespace %q is Stopped\n", vm.Name, f.Namespace.Name)
 		})
 
 		It("VM with NAD-OVN should be backed up and restored to a different namespace with namespace mapping", func() {
@@ -882,8 +889,9 @@ var _ = Describe("[smoke] VM Backup", func() {
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusRunning)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Dumping VM YAML before backup")
+			By("Dumping VM and NAD YAML before backup")
 			dumpVMYaml(f.KvClient, f.Namespace.Name, vm.Name)
+			dumpNADYaml(f, nadName, f.Namespace.Name)
 
 			By("Creating backup with label selector (only VM is labeled, NAD must be discovered by plugin)")
 			err = f.RunBackupScript(timeout, backupName, "", "a.test.label=included", f.Namespace.Name, snapshotLocation, f.BackupNamespace)
@@ -895,35 +903,42 @@ var _ = Describe("[smoke] VM Backup", func() {
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Creating restore with namespace mapping")
+			By("Creating restore with namespace mapping and clear MAC address")
 			err = framework.CreateRestoreWithNamespaceMapping(timeout, backupName, restoreName, f.BackupNamespace,
-				map[string]string{f.Namespace.Name: targetNs.Name}, true)
+				map[string]string{f.Namespace.Name: targetNs.Name},
+				map[string]string{"velero.kubevirt.io/clear-mac-address": "true"},
+				true)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying VM")
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, targetNs.Name, vm.Name, kvv1.VirtualMachineStatusStopped, kvv1.VirtualMachineStatusRunning)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Dumping VM YAML after restore")
+			By("Dumping VM and NAD YAML after restore")
 			dumpVMYaml(f.KvClient, targetNs.Name, vm.Name)
+			dumpNADYaml(f, nadName, targetNs.Name)
 
 			By("Verifying NetworkAttachmentDefinition was restored")
 			nadRestored, err := getNetworkAttachmentDefinition(f, nadName, targetNs.Name)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "INFO: NAD %q in namespace %q: %s\n", nadName, targetNs.Name, nadRestored)
 			Expect(nadRestored).ToNot(BeEmpty(), "NAD should have been restored")
 
 			By("Verifying NAD config has remapped netAttachDefName to target namespace")
 			nadConfig, err := getNetworkAttachmentDefinitionConfig(f, nadName, targetNs.Name)
 			Expect(err).ToNot(HaveOccurred())
 			expectedNetAttachDefName := fmt.Sprintf("%s/%s", targetNs.Name, nadName)
+			fmt.Fprintf(GinkgoWriter, "INFO: NAD config: %s\n", nadConfig)
+			fmt.Fprintf(GinkgoWriter, "INFO: Expected netAttachDefName substring: %s\n", expectedNetAttachDefName)
 			Expect(nadConfig).To(ContainSubstring(expectedNetAttachDefName),
-				fmt.Sprintf("NAD config should reference target namespace: expected %s in config", expectedNetAttachDefName))
+				fmt.Sprintf("NAD config should reference target namespace: expected %s in config %s", expectedNetAttachDefName, nadConfig))
 
 			By("Verifying VM still references the NAD in its spec")
 			restoredVM, err := f.KvClient.VirtualMachine(targetNs.Name).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			foundNAD := false
 			for _, net := range restoredVM.Spec.Template.Spec.Networks {
+				fmt.Fprintf(GinkgoWriter, "INFO: VM network entry: Name=%s, Multus=%v\n", net.Name, net.Multus)
 				if net.Multus != nil && net.Multus.NetworkName == nadName {
 					foundNAD = true
 					break
@@ -934,6 +949,7 @@ var _ = Describe("[smoke] VM Backup", func() {
 			By("Verifying original VM still exists in source namespace")
 			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
 			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "INFO: Original VM %q in source namespace %q is Stopped\n", vm.Name, f.Namespace.Name)
 		})
 
 		//todo this test vm is not starting correctly, need more eyes to fix.
@@ -1092,6 +1108,31 @@ func dumpVMYaml(kvClient kubecli.KubevirtClient, namespace, name string) {
 		return
 	}
 	fmt.Fprintf(GinkgoWriter, "=== VM %s/%s YAML ===\n%s\n=== End VM ===\n", namespace, name, string(data))
+}
+
+func dumpNADYaml(f *framework.Framework, name, namespace string) {
+	cfg, err := f.LoadConfig()
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "WARN: failed to load config for NAD dump: %v\n", err)
+		return
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "WARN: failed to create dynamic client for NAD dump: %v\n", err)
+		return
+	}
+	nadGVR := schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}
+	nad, err := dynClient.Resource(nadGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "WARN: failed to get NAD %s/%s for dump: %v\n", namespace, name, err)
+		return
+	}
+	data, err := json.MarshalIndent(nad.Object, "", "  ")
+	if err != nil {
+		fmt.Fprintf(GinkgoWriter, "WARN: failed to marshal NAD %s/%s: %v\n", namespace, name, err)
+		return
+	}
+	fmt.Fprintf(GinkgoWriter, "=== NAD %s/%s ===\n%s\n=== End NAD ===\n", namespace, name, string(data))
 }
 
 func deleteNetworkAttachmentDefinition(f *framework.Framework, name, namespace string) error {

--- a/tests/vm_backup_test.go
+++ b/tests/vm_backup_test.go
@@ -783,6 +783,159 @@ var _ = Describe("[smoke] VM Backup", func() {
 			Expect(foundNAD).To(BeTrue(), "Restored VM should reference the NAD")
 		})
 
+		It("VM with NAD should be backed up and restored to a different namespace with namespace mapping", func() {
+			_, err := f.K8sClient.Discovery().ServerResourcesForGroupVersion("k8s.cni.cncf.io/v1")
+			if err != nil {
+				Skip("NetworkAttachmentDefinition CRD not available on this cluster")
+			}
+
+			const nadName = "test-nad"
+
+			By("Creating target namespace for namespace-mapped restore")
+			targetNs, err := f.CreateNamespace()
+			Expect(err).ToNot(HaveOccurred())
+			f.AddNamespaceToDelete(targetNs)
+
+			By("Creating NetworkAttachmentDefinition")
+			err = f.CreateNetworkAttachmentDefinition()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Starting a VM with Multus secondary network")
+			err = f.CreateVMWithNAD()
+			Expect(err).ToNot(HaveOccurred())
+			vm, err = framework.WaitVirtualMachineRunning(f.KvClient, f.Namespace.Name, "test-vm-with-nad", dvName)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusRunning)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Dumping VM YAML before backup")
+			dumpVMYaml(f.KvClient, f.Namespace.Name, vm.Name)
+
+			By("Creating backup with label selector (only VM is labeled, NAD must be discovered by plugin)")
+			err = f.RunBackupScript(timeout, backupName, "", "a.test.label=included", f.Namespace.Name, snapshotLocation, f.BackupNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Stopping VM")
+			err = framework.StopVirtualMachine(f.KvClient, f.Namespace.Name, vm.Name)
+			Expect(err).ToNot(HaveOccurred())
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating restore with namespace mapping")
+			err = framework.CreateRestoreWithNamespaceMapping(timeout, backupName, restoreName, f.BackupNamespace,
+				map[string]string{f.Namespace.Name: targetNs.Name}, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying VM")
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, targetNs.Name, vm.Name, kvv1.VirtualMachineStatusStopped, kvv1.VirtualMachineStatusRunning)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Dumping VM YAML after restore")
+			dumpVMYaml(f.KvClient, targetNs.Name, vm.Name)
+
+			By("Verifying NetworkAttachmentDefinition was restored")
+			nadRestored, err := getNetworkAttachmentDefinition(f, nadName, targetNs.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nadRestored).ToNot(BeEmpty(), "NAD should have been restored")
+
+			By("Verifying VM still references the NAD in its spec")
+			restoredVM, err := f.KvClient.VirtualMachine(targetNs.Name).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			foundNAD := false
+			for _, net := range restoredVM.Spec.Template.Spec.Networks {
+				if net.Multus != nil && net.Multus.NetworkName == nadName {
+					foundNAD = true
+					break
+				}
+			}
+			Expect(foundNAD).To(BeTrue(), "Restored VM should reference the NAD")
+
+			By("Verifying original VM still exists in source namespace")
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("VM with NAD-OVN should be backed up and restored to a different namespace with namespace mapping", func() {
+			_, err := f.K8sClient.Discovery().ServerResourcesForGroupVersion("k8s.cni.cncf.io/v1")
+			if err != nil {
+				Skip("NetworkAttachmentDefinition CRD not available on this cluster")
+			}
+
+			const nadName = "nad-1"
+
+			By("Creating target namespace for namespace-mapped restore")
+			targetNs, err := f.CreateNamespace()
+			Expect(err).ToNot(HaveOccurred())
+			f.AddNamespaceToDelete(targetNs)
+
+			By("Creating NetworkAttachmentDefinition")
+			err = f.CreateNetworkAttachmentDefinitionOvn()
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Starting a VM with Multus secondary network")
+			err = f.CreateVMWithNADOvn()
+			Expect(err).ToNot(HaveOccurred())
+			vm, err = framework.WaitVirtualMachineRunning(f.KvClient, f.Namespace.Name, "test-vm-with-nad-ovn", dvName)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusRunning)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Dumping VM YAML before backup")
+			dumpVMYaml(f.KvClient, f.Namespace.Name, vm.Name)
+
+			By("Creating backup with label selector (only VM is labeled, NAD must be discovered by plugin)")
+			err = f.RunBackupScript(timeout, backupName, "", "a.test.label=included", f.Namespace.Name, snapshotLocation, f.BackupNamespace)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Stopping VM")
+			err = framework.StopVirtualMachine(f.KvClient, f.Namespace.Name, vm.Name)
+			Expect(err).ToNot(HaveOccurred())
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating restore with namespace mapping")
+			err = framework.CreateRestoreWithNamespaceMapping(timeout, backupName, restoreName, f.BackupNamespace,
+				map[string]string{f.Namespace.Name: targetNs.Name}, true)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Verifying VM")
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, targetNs.Name, vm.Name, kvv1.VirtualMachineStatusStopped, kvv1.VirtualMachineStatusRunning)
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Dumping VM YAML after restore")
+			dumpVMYaml(f.KvClient, targetNs.Name, vm.Name)
+
+			By("Verifying NetworkAttachmentDefinition was restored")
+			nadRestored, err := getNetworkAttachmentDefinition(f, nadName, targetNs.Name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(nadRestored).ToNot(BeEmpty(), "NAD should have been restored")
+
+			By("Verifying NAD config has remapped netAttachDefName to target namespace")
+			nadConfig, err := getNetworkAttachmentDefinitionConfig(f, nadName, targetNs.Name)
+			Expect(err).ToNot(HaveOccurred())
+			expectedNetAttachDefName := fmt.Sprintf("%s/%s", targetNs.Name, nadName)
+			Expect(nadConfig).To(ContainSubstring(expectedNetAttachDefName),
+				fmt.Sprintf("NAD config should reference target namespace: expected %s in config", expectedNetAttachDefName))
+
+			By("Verifying VM still references the NAD in its spec")
+			restoredVM, err := f.KvClient.VirtualMachine(targetNs.Name).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			foundNAD := false
+			for _, net := range restoredVM.Spec.Template.Spec.Networks {
+				if net.Multus != nil && net.Multus.NetworkName == nadName {
+					foundNAD = true
+					break
+				}
+			}
+			Expect(foundNAD).To(BeTrue(), "Restored VM should reference the NAD")
+
+			By("Verifying original VM still exists in source namespace")
+			err = framework.WaitForVirtualMachineStatus(f.KvClient, f.Namespace.Name, vm.Name, kvv1.VirtualMachineStatusStopped)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		//todo this test vm is not starting correctly, need more eyes to fix.
 		PIt("[test_id:10275]VM with hotplug disk", Label("PartnerComp"), func() {
 			By("Starting a VM")
@@ -973,6 +1126,31 @@ func getNetworkAttachmentDefinition(f *framework.Framework, name, namespace stri
 		return "", err
 	}
 	return nad.GetName(), nil
+}
+
+func getNetworkAttachmentDefinitionConfig(f *framework.Framework, name, namespace string) (string, error) {
+	cfg, err := f.LoadConfig()
+	if err != nil {
+		return "", err
+	}
+	dynClient, err := dynamic.NewForConfig(cfg)
+	if err != nil {
+		return "", err
+	}
+	nadGVR := schema.GroupVersionResource{Group: "k8s.cni.cncf.io", Version: "v1", Resource: "network-attachment-definitions"}
+	nad, err := dynClient.Resource(nadGVR).Namespace(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	spec, ok := nad.Object["spec"].(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("NAD %s/%s spec not found or not a map", namespace, name)
+	}
+	config, ok := spec["config"].(string)
+	if !ok {
+		return "", fmt.Errorf("NAD %s/%s config not found or not a string", namespace, name)
+	}
+	return config, nil
 }
 
 func getPersistentStatePVC(kvClient kubecli.KubevirtClient, vm *kvv1.VirtualMachine) (*v1.PersistentVolumeClaim, error) {


### PR DESCRIPTION
* add NetworkAttachmentDefinition restore item action plugin
* use resource rather than kind in AppliesTo
* Tests w/ namespace mapping to new restore namespace
   *  test1 w/ bridge
   * test2 w/ ovn and namespace/device in config

to test:
```
1:  clear; KVP_BACKUP_NS=openshift-adp KUBECONFIG=~/.kube/config make test-functional-local TEST_ARGS='--test-args=-ginkgo.focus=NAD.*backed.*up.*restored.*different.*namespace'
```
```
2:  clear; KVP_BACKUP_NS=openshift-adp KUBECONFIG=~/.kube/config make test-functional-local TEST_ARGS='--test-args=-ginkgo.focus=NAD-OVN.*backed.*up.*restored.*different.*namespace'
```

test log
https://hackmd.io/@openshift-mig-eng/HJby8MPGMl

fixes: #363 https://github.com/kubevirt/kubevirt-velero-plugin/issues/363

-->
```release-note
Adds NetworkAttachmentDefinition plugin to handle namespace mapping
```

