### PR TITLE
[release-v0.7] Add OADP maintainers to kubevirt-plugin (#343)

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,6 +7,9 @@ aliases:
       - awels
       - mhenriks
       - ShellyKa13
+      - alromeros
+      - sseago
+      - shubham-pampattiwar
   code-reviewers:
       - tbaransk
       - aglitke
@@ -15,3 +18,6 @@ aliases:
       - maya-r
       - ShellyKa13
       - brybacki
+      - alromeros
+      - sseago
+      - shubham-pampattiwar


### PR DESCRIPTION
We already have OADP maintainers on newer branches, but earlier suppported OADP versions use v0.7, so we need to be added here as well.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

