### PR TITLE
[release-v0.8] OADP-8332: Add IBA plugin to ensure that pod hooks are run for VM pods

### DIFF
--- a/hack/velero/add-plugin.sh
+++ b/hack/velero/add-plugin.sh
@@ -33,7 +33,7 @@ function wait_plugin_available {
                     plugin get | grep kubevirt-velero | wc -l)
 
     wait_time=0
-    expected_actions="14"
+    expected_actions="15"
     while [[ $available != $expected_actions ]] && [[ $wait_time -lt 60 ]]; do
       wait_time=$((wait_time + 5))
       sleep 5

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-datavolume-action", newDVBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachine-action", newVMBackupItemAction).
 		RegisterBackupItemAction("kubevirt-velero-plugin/backup-virtualmachineinstance-action", newVMIBackupItemAction).
+		RegisterItemBlockAction("kubevirt-velero-plugin/block-vm-action", newVMItemBlockAction).
 		Serve()
 }
 
@@ -59,6 +60,11 @@ func newVMIBackupItemAction(logger logrus.FieldLogger) (interface{}, error) {
 	}
 
 	return plugin.NewVMIBackupItemAction(logger, client), nil
+}
+
+func newVMItemBlockAction(logger logrus.FieldLogger) (interface{}, error) {
+	logger.Debug("Creating VMItemBlockAction")
+	return plugin.NewVMItemBlockAction(logger), nil
 }
 
 func newVMRestoreItemAction(logger logrus.FieldLogger) (interface{}, error) {

--- a/pkg/plugin/vm_item_block_action.go
+++ b/pkg/plugin/vm_item_block_action.go
@@ -1,0 +1,58 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"github.com/sirupsen/logrus"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"github.com/vmware-tanzu/velero/pkg/plugin/velero"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"kubevirt.io/kubevirt-velero-plugin/pkg/util/kvgraph"
+)
+
+// VMItemBlockAction is an item block action for VirtualMachines
+type VMItemBlockAction struct {
+	log logrus.FieldLogger
+}
+
+// NewVMItemBlockAction instantiates a VMItemBlockAction.
+func NewVMItemBlockAction(log logrus.FieldLogger) *VMItemBlockAction {
+	return &VMItemBlockAction{log: log}
+}
+
+// AppliesTo returns information about which resources this action should be invoked for.
+func (p *VMItemBlockAction) AppliesTo() (velero.ResourceSelector, error) {
+	return velero.ResourceSelector{
+		IncludedResources: []string{
+			"virtualmachines.kubevirt.io",
+		},
+	}, nil
+}
+
+// GetRelatedItems returns the related items for the VirtualMachine using the backup graph.
+func (p *VMItemBlockAction) GetRelatedItems(item runtime.Unstructured, backup *v1.Backup) ([]velero.ResourceIdentifier, error) {
+	p.log.Info("Executing VMItemBlockAction GetRelatedItems")
+	return kvgraph.NewObjectBackupGraph(item)
+}
+
+func (p *VMItemBlockAction) Name() string {
+	return "VMItemBlockAction"
+}

--- a/pkg/plugin/vm_item_block_action_test.go
+++ b/pkg/plugin/vm_item_block_action_test.go
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the Kubevirt Velero Plugin project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2025 Red Hat, Inc.
+ *
+ */
+
+package plugin
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	v1 "github.com/vmware-tanzu/velero/pkg/apis/velero/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestVMItemBlockAction_AppliesTo(t *testing.T) {
+	logger := logrus.StandardLogger()
+	action := NewVMItemBlockAction(logger)
+
+	selector, err := action.AppliesTo()
+	assert.NoError(t, err)
+	assert.Contains(t, selector.IncludedResources, "virtualmachines.kubevirt.io")
+}
+
+func TestVMItemBlockAction_GetRelatedItems(t *testing.T) {
+	logger := logrus.StandardLogger()
+	action := NewVMItemBlockAction(logger)
+	backup := &v1.Backup{}
+
+	t.Run("Valid VirtualMachine", func(t *testing.T) {
+		unstructuredItem := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kubevirt.io",
+				"kind":       "VirtualMachine",
+				"metadata": map[string]interface{}{
+					"name":      "test-vm",
+					"namespace": testNamespace,
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"volumes": []map[string]interface{}{
+								map[string]interface{}{
+									"name": "vol",
+									"dataVolume": map[string]interface{}{
+										"name": "test-dv",
+									},
+								},
+							},
+						},
+					},
+				},
+				"status": map[string]interface{}{
+					"created":         true,
+					"printableStatus": "Running",
+				},
+			},
+		}
+		
+		// We expect no error during conversion and execution
+		relatedItems, err := action.GetRelatedItems(unstructuredItem, backup)
+		assert.NoError(t, err)
+		assert.NotNil(t, relatedItems)
+		assert.Equal(t, len(relatedItems), 3)
+	})
+
+	t.Run("Invalid Unstructured Data", func(t *testing.T) {
+		invalidItem := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": "this-should-be-a-map-not-a-string",
+			},
+		}
+
+		relatedItems, err := action.GetRelatedItems(invalidItem, backup)
+		assert.NoError(t, err)
+		assert.Equal(t, len(relatedItems), 0)
+	})
+}

--- a/pkg/util/kvgraph/backup_graph.go
+++ b/pkg/util/kvgraph/backup_graph.go
@@ -77,7 +77,9 @@ func NewVirtualMachineBackupGraph(vm *v1.VirtualMachine) ([]velero.ResourceIdent
 		}
 	}
 
-	resources, err = addCommonVMIObjectGraph(vm.Spec.Template.Spec, vm.GetName(), namespace, resources)
+	if vm.Spec.Template != nil {
+		resources, err = addCommonVMIObjectGraph(vm.Spec.Template.Spec, vm.GetName(), namespace, resources)
+	}
 	if err != nil {
 		errs = append(errs, err)
 	}


### PR DESCRIPTION
cherry-pick of #441 
* feat: add VMItemBlockAction plugin for VirtualMachine resources




* fixed imports



* fixed test



* fixed npe



* added missing plugin interface method



* updated action count to include new IBA



* incorporated review feedback



---------

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

